### PR TITLE
First attempt at implementing wildcard paths

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -18,6 +18,7 @@ type confPath struct {
 	SourceProtocol       string                   `yaml:"sourceProtocol"`
 	sourceProtocolParsed gortsplib.StreamProtocol ``
 	SourceOnDemand       bool                     `yaml:"sourceOnDemand"`
+	IsWildcard           bool                     `yaml:"isWildcard"`
 	RunOnInit            string                   `yaml:"runOnInit"`
 	RunOnDemand          string                   `yaml:"runOnDemand"`
 	RunOnPublish         string                   `yaml:"runOnPublish"`
@@ -189,6 +190,11 @@ func loadConf(fpath string, stdin io.Reader) (*conf, error) {
 				return nil, fmt.Errorf("path 'all' cannot have a RTSP source; use another path")
 			}
 
+			if confp.SourceOnDemand && confp.IsWildcard {
+				return nil, fmt.Errorf("wildcard paths must not be sourced on demand; set sourceOnDemand to no");
+			}
+
+
 			if confp.SourceProtocol == "" {
 				confp.SourceProtocol = "udp"
 			}
@@ -263,6 +269,7 @@ func loadConf(fpath string, stdin io.Reader) (*conf, error) {
 		if confp.RunOnDemand != "" && path == "all" {
 			return nil, fmt.Errorf("path 'all' does not support option 'runOnDemand'; use another path")
 		}
+
 	}
 
 	return conf, nil

--- a/path.go
+++ b/path.go
@@ -23,6 +23,7 @@ type path struct {
 	publisherReady     bool
 	publisherSdpText   []byte
 	publisherSdpParsed *sdp.SessionDescription
+	consumerConnected  bool
 	lastRequested      time.Time
 	lastActivation     time.Time
 	onDemandCmd        *exec.Cmd
@@ -122,6 +123,9 @@ func (pa *path) describe(client *client) {
 
 				pa.lastActivation = time.Now()
 				pa.onDemandCmd = exec.Command("/bin/sh", "-c", pa.confp.RunOnDemand)
+				pa.onDemandCmd.Env = append(os.Environ(),
+					"RTSP_SERVER_PATH="+pa.id,
+				)
 				pa.onDemandCmd.Stdout = os.Stdout
 				pa.onDemandCmd.Stderr = os.Stderr
 				err := pa.onDemandCmd.Start()

--- a/rtsp-simple-server.yml
+++ b/rtsp-simple-server.yml
@@ -40,6 +40,12 @@ paths:
     # is connected, saving bandwidth
     sourceOnDemand: no
 
+    # make this path a wildcard, that matches any path that starts with what is specified.
+    # if the source is an RTSP url, sourceOnDemand must be off
+    # when using runOnInit/runOnDemand/runOnPublish/runOnRead, the actual path is available
+    # as an environment variable RTSP_SERVER_PATH
+    isWildcard: no
+
     # command to run when this path is loaded by the program.
     # this can be used, for example, to publish a stream and keep it always opened.
     # This is terminated with SIGINT when the program closes.


### PR DESCRIPTION
Apologies for the duplicate earlier on, should have been less jumpy about opening an issue!

First attempt at getting this working, based on my limited understanding of RTSP and the code structure.

This patch introduces a new configuration item: `isWildcard`, that causes the configured path to be matched against any path that begins with it. The `runOnInit`/`runOnDemand`/`runOnPublish`/`runOnRead` callers have also been modified to set an environment variable RTSP_SERVER_PATH with the calling path. (For runOnInit, it will be called with the configured path, of course)

`findConfForPath()` has been modified to return an additional string - the configured path that was matched. It isn't necessary at the moment (only used to print out logs), but might be useful to have.

There are some doubts I have:
- Possibly incorrect behaviour if `isWildcard` is set for the 'all' path
- Unsure if there will be odd interactions with sourceOnDemand, thus currently there is a check to make sure that sourceOnDemand is off when isWildcard is on
- It seems like it should be sufficient to handle adding the dynamic path during the describe event, but I may be wrong
- There is a check to only destroy the dynamic path when both the producer and consumers are disconnected, but it possibly does not handle multiple clients connecting to the same path correctly
- I have only tested this for my use case, which is with dynamically generated recorder streams, and only one client per path
- The environment variable name should probably be a configuration item, and it should be possible to turn the feature off

Do let me know how I can improve the patch for acceptance, thanks!

(Addresses #47 )