### PR TITLE
implement simple handling of wildcard paths

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -18,6 +18,7 @@ type confPath struct {
 	SourceProtocol       string                   `yaml:"sourceProtocol"`
 	sourceProtocolParsed gortsplib.StreamProtocol ``
 	SourceOnDemand       bool                     `yaml:"sourceOnDemand"`
+	IsWildcard           bool                     `yaml:"isWildcard"`
 	RunOnInit            string                   `yaml:"runOnInit"`
 	RunOnDemand          string                   `yaml:"runOnDemand"`
 	RunOnPublish         string                   `yaml:"runOnPublish"`
@@ -187,6 +188,10 @@ func loadConf(fpath string, stdin io.Reader) (*conf, error) {
 		if confp.Source != "record" {
 			if path == "all" {
 				return nil, fmt.Errorf("path 'all' cannot have a RTSP source; use another path")
+			}
+
+			if confp.SourceOnDemand && confp.IsWildcard {
+				return nil, fmt.Errorf("wildcard paths must not be sourced on demand; set sourceOnDemand to 'no'");
 			}
 
 			if confp.SourceProtocol == "" {

--- a/path.go
+++ b/path.go
@@ -23,6 +23,7 @@ type path struct {
 	publisherReady     bool
 	publisherSdpText   []byte
 	publisherSdpParsed *sdp.SessionDescription
+	consumerConnected  bool
 	lastRequested      time.Time
 	lastActivation     time.Time
 	onDemandCmd        *exec.Cmd
@@ -136,6 +137,7 @@ func (pa *path) describe(client *client) {
 		}
 
 		// no on-demand: reply with 404
+		pa.consumerConnected = false
 		client.describeRes <- describeRes{nil, fmt.Errorf("no one is publishing on path '%s'", pa.id)}
 		return
 	}

--- a/rtsp-simple-server.yml
+++ b/rtsp-simple-server.yml
@@ -40,6 +40,10 @@ paths:
     # is connected, saving bandwidth
     sourceOnDemand: no
 
+    # make this path a wildcard, that matches any path that starts with what is specified.
+    # if the source is an RTSP url, sourceOnDemand must be set to 'no'
+    isWildcard: no
+
     # command to run when this path is loaded by the program.
     # this can be used, for example, to publish a stream and keep it always opened.
     # This is terminated with SIGINT when the program closes.


### PR DESCRIPTION
This patch introduces a new configuration item: `isWildcard`, that causes the configured path to be matched against any path that begins with it.

`findConfForPath()` has been modified to return an additional string - the configured path that was matched. It isn't necessary at the moment (only used to print out logs), but might be useful to have.

There are some doubts I have:
- Possibly incorrect behaviour if `isWildcard` is set for the 'all' path
- Unsure if there will be odd interactions with `sourceOnDemand`, thus currently there is a check to make sure that `sourceOnDemand` is off when `isWildcard` is on
- Possible weird interactions with the newly implemented feature for handling control paths (d0c2c3a58653ea7fe650c5eb851c228615149beb)
- It seems like it should be sufficient to handle adding the dynamic path during the describe event, but I may be wrong
- There is a check to only destroy the dynamic path when both the producer and consumers are disconnected, but it possibly does not handle multiple clients connecting to the same path correctly
- I have only tested this for my use case, which is with dynamically generated recorder streams, and only one client per path

Do let me know how I can improve the patch for acceptance, thanks!