### PR TITLE
expose request path to runOn commands as an environment variable

### DIFF
--- a/client.go
+++ b/client.go
@@ -829,6 +829,9 @@ func (c *client) runPlay(path string) {
 	var onReadCmd *exec.Cmd
 	if confp.RunOnRead != "" {
 		onReadCmd = exec.Command("/bin/sh", "-c", confp.RunOnRead)
+		onReadCmd.Env = append(os.Environ(),
+			"RTSP_SERVER_PATH="+path,
+		)
 		onReadCmd.Stdout = os.Stdout
 		onReadCmd.Stderr = os.Stderr
 		err := onReadCmd.Start()
@@ -928,6 +931,9 @@ func (c *client) runRecord(path string) {
 	var onPublishCmd *exec.Cmd
 	if confp.RunOnPublish != "" {
 		onPublishCmd = exec.Command("/bin/sh", "-c", confp.RunOnPublish)
+		onPublishCmd.Env = append(os.Environ(),
+			"RTSP_SERVER_PATH="+path,
+		)
 		onPublishCmd.Stdout = os.Stdout
 		onPublishCmd.Stderr = os.Stderr
 		err := onPublishCmd.Start()

--- a/client.go
+++ b/client.go
@@ -830,7 +830,7 @@ func (c *client) runPlay(path string) {
 	if confp.RunOnRead != "" {
 		onReadCmd = exec.Command("/bin/sh", "-c", confp.RunOnRead)
 		onReadCmd.Env = append(os.Environ(),
-			"RTSP_SERVER_PATH="+path,
+			c.p.conf.PathEnvVariable+"="+path,
 		)
 		onReadCmd.Stdout = os.Stdout
 		onReadCmd.Stderr = os.Stderr
@@ -932,7 +932,7 @@ func (c *client) runRecord(path string) {
 	if confp.RunOnPublish != "" {
 		onPublishCmd = exec.Command("/bin/sh", "-c", confp.RunOnPublish)
 		onPublishCmd.Env = append(os.Environ(),
-			"RTSP_SERVER_PATH="+path,
+			c.p.conf.PathEnvVariable+"="+path,
 		)
 		onPublishCmd.Stdout = os.Stdout
 		onPublishCmd.Stderr = os.Stderr

--- a/conf.go
+++ b/conf.go
@@ -41,6 +41,7 @@ type conf struct {
 	RunOnConnect          string                                `yaml:"runOnConnect"`
 	ReadTimeout           time.Duration                         `yaml:"readTimeout"`
 	WriteTimeout          time.Duration                         `yaml:"writeTimeout"`
+	PathEnvVariable       string                                `yaml:"pathEnvVariable"`
 	AuthMethods           []string                              `yaml:"authMethods"`
 	authMethodsParsed     []gortsplib.AuthMethod                ``
 	Metrics               bool                                  `yaml:"metrics"`
@@ -130,6 +131,14 @@ func loadConf(fpath string, stdin io.Reader) (*conf, error) {
 	}
 	if conf.WriteTimeout == 0 {
 		conf.WriteTimeout = 5 * time.Second
+	}
+
+	if conf.PathEnvVariable == "" {
+		conf.PathEnvVariable = "RTSP_SERVER_PATH"
+	}
+	re := regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+	if !re.MatchString(conf.PathEnvVariable) {
+		return nil, fmt.Errorf("pathEnvVariable must consist of only alphanumerics and underscores, and should not begin with a digit")
 	}
 
 	if len(conf.AuthMethods) == 0 {

--- a/main.go
+++ b/main.go
@@ -260,9 +260,12 @@ func newProgram(args []string, stdin io.Reader) (*program, error) {
 		return nil, err
 	}
 
-	for _, confp := range conf.Paths {
+	for path, confp := range conf.Paths {
 		if confp.RunOnInit != "" {
 			onInitCmd := exec.Command("/bin/sh", "-c", confp.RunOnInit)
+			onInitCmd.Env = append(os.Environ(),
+				"RTSP_SERVER_PATH="+path,
+			)
 			onInitCmd.Stdout = os.Stdout
 			onInitCmd.Stderr = os.Stderr
 			err := onInitCmd.Start()

--- a/main.go
+++ b/main.go
@@ -264,7 +264,7 @@ func newProgram(args []string, stdin io.Reader) (*program, error) {
 		if confp.RunOnInit != "" {
 			onInitCmd := exec.Command("/bin/sh", "-c", confp.RunOnInit)
 			onInitCmd.Env = append(os.Environ(),
-				"RTSP_SERVER_PATH="+path,
+				conf.PathEnvVariable+"="+path,
 			)
 			onInitCmd.Stdout = os.Stdout
 			onInitCmd.Stderr = os.Stderr

--- a/path.go
+++ b/path.go
@@ -123,7 +123,7 @@ func (pa *path) describe(client *client) {
 				pa.lastActivation = time.Now()
 				pa.onDemandCmd = exec.Command("/bin/sh", "-c", pa.confp.RunOnDemand)
 				pa.onDemandCmd.Env = append(os.Environ(),
-					"RTSP_SERVER_PATH="+pa.id,
+					pa.p.conf.PathEnvVariable+"="+pa.id,
 				)
 				pa.onDemandCmd.Stdout = os.Stdout
 				pa.onDemandCmd.Stderr = os.Stderr

--- a/path.go
+++ b/path.go
@@ -122,6 +122,9 @@ func (pa *path) describe(client *client) {
 
 				pa.lastActivation = time.Now()
 				pa.onDemandCmd = exec.Command("/bin/sh", "-c", pa.confp.RunOnDemand)
+				pa.onDemandCmd.Env = append(os.Environ(),
+					"RTSP_SERVER_PATH="+pa.id,
+				)
 				pa.onDemandCmd.Stdout = os.Stdout
 				pa.onDemandCmd.Stderr = os.Stderr
 				err := pa.onDemandCmd.Start()

--- a/rtsp-simple-server.yml
+++ b/rtsp-simple-server.yml
@@ -14,6 +14,8 @@ runOnConnect:
 readTimeout: 10s
 # timeout of write operations
 writeTimeout: 5s
+# name of environment variable used to pass the path to runOnInit/Demand/Publish/Read
+pathEnvVariable: RTSP_SERVER_PATH
 # supported authentication methods
 # WARNING: both methods are insecure, use RTSP inside a VPN to enforce security.
 authMethods: [basic, digest]
@@ -43,26 +45,26 @@ paths:
     # command to run when this path is loaded by the program.
     # this can be used, for example, to publish a stream and keep it always opened.
     # This is terminated with SIGINT when the program closes.
-    # The path is available as an environment variable $RTSP_SERVER_PATH
+    # The path is available as an environment variable configured by pathEnvVariable
     runOnInit:
 
     # command to run when this path is requested.
     # This can be used, for example, to publish a stream on demand.
     # This is terminated with SIGINT when the path is not requested anymore.
     # The actual path from the request (useful for wildcard paths) is available as an
-    # environment variable $RTSP_SERVER_PATH
+    # environment variable configured by pathEnvVariable
     runOnDemand:
 
     # command to run when a client starts publishing.
     # This is terminated with SIGINT when a client stops publishing.
     # The actual path from the client (useful for wildcard paths) is available as an
-    # environment variable $RTSP_SERVER_PATH
+    # environment variable configured by pathEnvVariable
     runOnPublish:
 
     # command to run when a clients starts reading.
     # This is terminated with SIGINT when a client stops reading.
     # The actual path from the client (useful for wildcard paths) is available as an
-    # environment variable $RTSP_SERVER_PATH
+    # environment variable configured by pathEnvVariable
     runOnRead:
 
     # username required to publish

--- a/rtsp-simple-server.yml
+++ b/rtsp-simple-server.yml
@@ -43,19 +43,26 @@ paths:
     # command to run when this path is loaded by the program.
     # this can be used, for example, to publish a stream and keep it always opened.
     # This is terminated with SIGINT when the program closes.
+    # The path is available as an environment variable $RTSP_SERVER_PATH
     runOnInit:
 
     # command to run when this path is requested.
     # This can be used, for example, to publish a stream on demand.
     # This is terminated with SIGINT when the path is not requested anymore.
+    # The actual path from the request (useful for wildcard paths) is available as an
+    # environment variable $RTSP_SERVER_PATH
     runOnDemand:
 
     # command to run when a client starts publishing.
     # This is terminated with SIGINT when a client stops publishing.
+    # The actual path from the client (useful for wildcard paths) is available as an
+    # environment variable $RTSP_SERVER_PATH
     runOnPublish:
 
     # command to run when a clients starts reading.
     # This is terminated with SIGINT when a client stops reading.
+    # The actual path from the client (useful for wildcard paths) is available as an
+    # environment variable $RTSP_SERVER_PATH
     runOnRead:
 
     # username required to publish


### PR DESCRIPTION
This patch modifies the `runOnInit`/`runOnDemand`/`runOnPublish`/`runOnRead` callers to set an environment variable with the calling path. (For `runOnInit`, it will be called with the configured path, of course)

A `pathEnvVariable` configuration item is also introduced to specify the name of the environment variable to be used. Its default value is `RTSP_SERVER_PATH` and there is sanity checking to ensure that the provided name is valid (alphanumeric + underscore, no leading digit).

(Addresses #47)