### PR TITLE
Kill processes instead of interrupting them

### DIFF
--- a/client.go
+++ b/client.go
@@ -206,7 +206,7 @@ func (c *client) run() {
 	}
 
 	if onConnectCmd != nil {
-		onConnectCmd.Process.Signal(os.Interrupt)
+		onConnectCmd.Process.Kill()
 		onConnectCmd.Wait()
 	}
 
@@ -914,7 +914,7 @@ func (c *client) runPlay() bool {
 	}
 
 	if onReadCmd != nil {
-		onReadCmd.Process.Signal(os.Interrupt)
+		onReadCmd.Process.Kill()
 		onReadCmd.Wait()
 	}
 
@@ -1065,7 +1065,7 @@ func (c *client) runRecord() bool {
 	}
 
 	if onPublishCmd != nil {
-		onPublishCmd.Process.Signal(os.Interrupt)
+		onPublishCmd.Process.Kill()
 		onPublishCmd.Wait()
 	}
 

--- a/path.go
+++ b/path.go
@@ -164,7 +164,7 @@ func (pa *path) onCheck() {
 		time.Since(pa.lastDescribeReq) >= onDemandCmdStopAfterDescribeSecs {
 		pa.log("stopping on demand command (not requested anymore)")
 		pa.onDemandCmd.Process.Kill()
-		pa.onDemandCmd.Kill()
+		pa.onDemandCmd.Wait()
 		pa.onDemandCmd = nil
 	}
 

--- a/path.go
+++ b/path.go
@@ -79,13 +79,13 @@ func (pa *path) onClose(wait bool) {
 
 	if pa.onInitCmd != nil {
 		pa.log("stopping on init command (closing)")
-		pa.onInitCmd.Process.Signal(os.Interrupt)
+		pa.onInitCmd.Process.Kill()
 		pa.onInitCmd.Wait()
 	}
 
 	if pa.onDemandCmd != nil {
 		pa.log("stopping on demand command (closing)")
-		pa.onDemandCmd.Process.Signal(os.Interrupt)
+		pa.onDemandCmd.Process.Kill()
 		pa.onDemandCmd.Wait()
 	}
 
@@ -163,8 +163,8 @@ func (pa *path) onCheck() {
 		!pa.hasClientReaders() &&
 		time.Since(pa.lastDescribeReq) >= onDemandCmdStopAfterDescribeSecs {
 		pa.log("stopping on demand command (not requested anymore)")
-		pa.onDemandCmd.Process.Signal(os.Interrupt)
-		pa.onDemandCmd.Wait()
+		pa.onDemandCmd.Process.Kill()
+		pa.onDemandCmd.Kill()
 		pa.onDemandCmd = nil
 	}
 


### PR DESCRIPTION
Kill custom commands instead of just interrupting them.
Why?:

- Interrupting not supported on Windows
- Libraries like VLC are not interrupting gracefully always. If a connection gets closed, the interrupt takes too much time to be executed until a potential new connection gets established. This leads to two processes of the same type are running, which can cause resource problems (like audio outout, ports, ...).

Just killing the processes is not the fine way, but more stable / reliable in this case.