### PR TITLE
improve config file watcher to support k8s configmap reloads

### DIFF
--- a/internal/confwatcher/confwatcher.go
+++ b/internal/confwatcher/confwatcher.go
@@ -83,7 +83,7 @@ outer:
 			eventPath, _ := filepath.Abs(event.Name)
 
 			if currentWatchedPath == "" {
-				// Watched file was removed wait for write event to trigger reload
+				// watched file was removed; wait for write event to trigger reload
 				previousWatchedPath = ""
 			} else if currentWatchedPath != previousWatchedPath ||
 				(eventPath == currentWatchedPath &&

--- a/internal/confwatcher/confwatcher.go
+++ b/internal/confwatcher/confwatcher.go
@@ -1,6 +1,7 @@
 package confwatcher
 
 import (
+	"os"
 	"path/filepath"
 	"time"
 
@@ -24,12 +25,16 @@ type ConfWatcher struct {
 
 // New allocates a ConfWatcher.
 func New(confPath string) (*ConfWatcher, error) {
+	if _, err := os.Stat(confPath); err != nil {
+		return nil, err
+	}
+
 	inner, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
 
-	// use absolute path to support Darwin
+	// use absolute paths to support Darwin
 	absolutePath, _ := filepath.Abs(confPath)
 	parentPath := filepath.Dir(absolutePath)
 

--- a/internal/confwatcher/confwatcher_test.go
+++ b/internal/confwatcher/confwatcher_test.go
@@ -29,7 +29,7 @@ func TestNoFile(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestFileWrite(t *testing.T) {
+func TestWrite(t *testing.T) {
 	fpath, err := writeTempFile([]byte("{}"))
 	require.NoError(t, err)
 
@@ -54,7 +54,7 @@ func TestFileWrite(t *testing.T) {
 	}
 }
 
-func TestFileWriteMultipleTimes(t *testing.T) {
+func TestWriteMultipleTimes(t *testing.T) {
 	fpath, err := writeTempFile([]byte("{}"))
 	require.NoError(t, err)
 
@@ -97,7 +97,7 @@ func TestFileWriteMultipleTimes(t *testing.T) {
 	}
 }
 
-/*func TestFileDeleteCreate(t *testing.T) {
+func TestDeleteCreate(t *testing.T) {
 	fpath, err := writeTempFile([]byte("{}"))
 	require.NoError(t, err)
 
@@ -105,22 +105,52 @@ func TestFileWriteMultipleTimes(t *testing.T) {
 	require.NoError(t, err)
 	defer w.Close()
 
-    os.Remove(fpath)
-    time.Sleep(10 * time.Millisecond)
+	os.Remove(fpath)
+	time.Sleep(10 * time.Millisecond)
 
-    func() {
-        f, err := os.Create(fpath)
-        require.NoError(t, err)
-        defer f.Close()
+	func() {
+		f, err := os.Create(fpath)
+		require.NoError(t, err)
+		defer f.Close()
 
-        _, err = f.Write([]byte("{}"))
-        require.NoError(t, err)
-    }()
+		_, err = f.Write([]byte("{}"))
+		require.NoError(t, err)
+	}()
 
 	select {
 	case <-w.Watch():
-	//case <-time.After(500 * time.Millisecond):
-	//	t.Errorf("timed out")
-    //    return
+	case <-time.After(500 * time.Millisecond):
+		t.Errorf("timed out")
+		return
 	}
-}*/
+}
+
+func TestSymlinkDeleteCreate(t *testing.T) {
+	fpath, err := writeTempFile([]byte("{}"))
+	require.NoError(t, err)
+
+	err = os.Symlink(fpath, fpath+"-sym")
+	require.NoError(t, err)
+
+	w, err := New(fpath + "-sym")
+	require.NoError(t, err)
+	defer w.Close()
+
+	os.Remove(fpath)
+
+	func() {
+		f, err := os.Create(fpath)
+		require.NoError(t, err)
+		defer f.Close()
+
+		_, err = f.Write([]byte("{}"))
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-w.Watch():
+	case <-time.After(500 * time.Millisecond):
+		t.Errorf("timed out")
+		return
+	}
+}


### PR DESCRIPTION
improve config file watcher to support k8s configmap reloads

The config file watcher assumed a simple configuration where the
existing configuration file is overwritten by a text editor.

In practice this does not detect some more complex configuration change
scenarios such as :
* The configuration file is behind a symlink and the symlink is updated
* The configuration file is behind a double symlink (k8s configmap
  update)
* The configuration file is not updated but removed the re-created

In order to fix these cases :
* Watch the configuration file parent directory instead of the file
itself, this lets us grab events event if the file was removed and a new
file is used.
* In addition to read/write event matching, watch for any change in
the configuration file path. This handles the symlink case where the
file itself hasn't changed but its location did