### PR TITLE
add ability to configure metrics port

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -58,6 +58,7 @@ type Conf struct {
 	WriteTimeout          time.Duration                   `yaml:"writeTimeout"`
 	ReadBufferCount       int                             `yaml:"readBufferCount"`
 	Metrics               bool                            `yaml:"metrics"`
+	MetricsPort           int                             `yaml:"metricsPort"`
 	Pprof                 bool                            `yaml:"pprof"`
 	RunOnConnect          string                          `yaml:"runOnConnect"`
 	RunOnConnectRestart   bool                            `yaml:"runOnConnectRestart"`
@@ -135,6 +136,10 @@ func (conf *Conf) fillAndCheck() error {
 	}
 	if conf.ReadBufferCount == 0 {
 		conf.ReadBufferCount = 512
+	}
+
+	if conf.MetricsPort == 0 {
+		conf.MetricsPort = 9998
 	}
 
 	if len(conf.Protocols) == 0 {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -13,10 +13,6 @@ import (
 	"github.com/aler9/rtsp-simple-server/internal/stats"
 )
 
-const (
-	port = 9998
-)
-
 func formatMetric(key string, value int64, nowUnix int64) string {
 	return key + " " + strconv.FormatInt(value, 10) + " " +
 		strconv.FormatInt(nowUnix, 10) + "\n"
@@ -39,11 +35,12 @@ type Metrics struct {
 // New allocates a metrics.
 func New(
 	listenIP string,
+	port int,
 	stats *stats.Stats,
 	parent Parent,
 ) (*Metrics, error) {
 
-	address := listenIP + ":" + strconv.FormatInt(port, 10)
+	address := listenIP + ":" + strconv.FormatInt(int64(port), 10)
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -164,6 +164,7 @@ func (p *program) createResources(initial bool) error {
 		if p.metrics == nil {
 			p.metrics, err = metrics.New(
 				p.conf.ListenIP,
+				p.conf.MetricsPort,
 				p.stats,
 				p)
 			if err != nil {
@@ -288,7 +289,8 @@ func (p *program) closeResources(newConf *conf.Conf) {
 	closeMetrics := false
 	if newConf == nil ||
 		newConf.Metrics != p.conf.Metrics ||
-		newConf.ListenIP != p.conf.ListenIP {
+		newConf.ListenIP != p.conf.ListenIP ||
+		newConf.MetricsPort != p.conf.MetricsPort {
 		closeMetrics = true
 	}
 

--- a/rtsp-simple-server.yml
+++ b/rtsp-simple-server.yml
@@ -20,8 +20,11 @@ writeTimeout: 10s
 # a lower number allows to save RAM.
 readBufferCount: 512
 
-# enable Prometheus-compatible metrics on port 9998.
+# enable Prometheus-compatible metrics.
 metrics: no
+# port of the metrics listener.
+metricsPort: 9998
+
 # enable pprof on port 9999 to monitor performances.
 pprof: no
 


### PR DESCRIPTION
Port could be specified by using either `metricsPort` config file entry or `RTSP_METRICSPORT` environment variable.