### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ api: yes
 The API listens on `apiAddress`, that by default is `127.0.0.1:9997`; for instance, to obtain a list of active paths, run:
 
 ```
-curl http//127.0.0.1:9997/list
+curl http://127.0.0.1:9997/list
 ```
 
 Full documentation of the API is available on the [dedicated site](https://aler9.github.io/rtsp-simple-server/).


### PR DESCRIPTION
Fixed curl command typo in HTTP API section of  README.md