### PR TITLE
ERR: sprop-parameter-sets is missing (96 profile-level-id=4D0014;pack…

### DIFF
--- a/internal/core/rtmp_conn.go
+++ b/internal/core/rtmp_conn.go
@@ -304,6 +304,14 @@ func (c *rtmpConn) runRead(ctx context.Context) error {
 	var videoPPS []byte
 	sendVideoSPSAndPPS := false
 
+	if videoTrack != nil {
+		conf, err := videoTrack.ExtractConfigH264()
+		if err == nil {
+			c.conn.WriteCodec(conf, audioTrack)
+			sendVideoSPSAndPPS = true
+		}
+	}
+
 	for {
 		data, ok := c.ringBuffer.Pull()
 		if !ok {
@@ -347,10 +355,10 @@ func (c *rtmpConn) runRead(ctx context.Context) error {
 			}
 
 			if videoSPS != nil && videoPPS != nil && !sendVideoSPSAndPPS {
-				c.conn.WriteCodec(videoTrack, audioTrack, &gortsplib.TrackConfigH264{
+				c.conn.WriteCodec(&gortsplib.TrackConfigH264{
 					SPS: videoSPS,
 					PPS: videoPPS,
-				})
+				}, audioTrack)
 				sendVideoSPSAndPPS = true
 			}
 

--- a/internal/rtmp/metadata.go
+++ b/internal/rtmp/metadata.go
@@ -207,10 +207,17 @@ func (c *Conn) WriteMetadata(videoTrack *gortsplib.Track, audioTrack *gortsplib.
 		return err
 	}
 
+	return nil
+}
+
+func (c *Conn) WriteCodec(videoTrack *gortsplib.Track, audioTrack *gortsplib.Track, vConf *gortsplib.TrackConfigH264) error {
 	if videoTrack != nil {
 		conf, err := videoTrack.ExtractConfigH264()
 		if err != nil {
-			return err
+			if vConf == nil {
+				return err
+			}
+			conf = vConf
 		}
 
 		codec := nh264.Codec{

--- a/internal/rtmp/metadata.go
+++ b/internal/rtmp/metadata.go
@@ -210,22 +210,14 @@ func (c *Conn) WriteMetadata(videoTrack *gortsplib.Track, audioTrack *gortsplib.
 	return nil
 }
 
-func (c *Conn) WriteCodec(videoTrack *gortsplib.Track, audioTrack *gortsplib.Track, vConf *gortsplib.TrackConfigH264) error {
-	if videoTrack != nil {
-		conf, err := videoTrack.ExtractConfigH264()
-		if err != nil {
-			if vConf == nil {
-				return err
-			}
-			conf = vConf
-		}
-
+func (c *Conn) WriteCodec(videoConf *gortsplib.TrackConfigH264, audioTrack *gortsplib.Track) error {
+	if videoConf != nil {
 		codec := nh264.Codec{
 			SPS: map[int][]byte{
-				0: conf.SPS,
+				0: videoConf.SPS,
 			},
 			PPS: map[int][]byte{
-				0: conf.PPS,
+				0: videoConf.PPS,
 			},
 		}
 		b := make([]byte, 128)
@@ -233,7 +225,7 @@ func (c *Conn) WriteCodec(videoTrack *gortsplib.Track, audioTrack *gortsplib.Tra
 		codec.ToConfig(b, &n)
 		b = b[:n]
 
-		err = c.WritePacket(av.Packet{
+		err := c.WritePacket(av.Packet{
 			Type: av.H264DecoderConfig,
 			Data: b,
 		})


### PR DESCRIPTION
In some rtsp stream, sdp may not have sps, pps data, it was passed in the NAULS data
When playing the rtmp stream, the following error will appear：

ERR: sprop-parameter-sets is missing (96 profile-level-id=4D0014;packetization-mode=0)
[https://github.com/aler9/gortsplib/issues/88](url)