### PR TITLE
rtsp_session: log error if config parsing fails

### DIFF
--- a/internal/core/rtsp_session.go
+++ b/internal/core/rtsp_session.go
@@ -131,7 +131,7 @@ func (s *rtspSession) onAnnounce(c *rtspConn, ctx *gortsplib.ServerHandlerOnAnno
 			if err != nil {
 				return &base.Response{
 					StatusCode: base.StatusBadRequest,
-				}, fmt.Errorf("track %d is not valid", i+1)
+				}, fmt.Errorf("H264 track %d is not valid: %v", i+1, err)
 			}
 		}
 
@@ -140,7 +140,7 @@ func (s *rtspSession) onAnnounce(c *rtspConn, ctx *gortsplib.ServerHandlerOnAnno
 			if err != nil {
 				return &base.Response{
 					StatusCode: base.StatusBadRequest,
-				}, fmt.Errorf("track %d is not valid", i+1)
+				}, fmt.Errorf("AAC track %d is not valid: %v", i+1, err)
 			}
 		}
 
@@ -149,7 +149,7 @@ func (s *rtspSession) onAnnounce(c *rtspConn, ctx *gortsplib.ServerHandlerOnAnno
 			if err != nil {
 				return &base.Response{
 					StatusCode: base.StatusBadRequest,
-				}, fmt.Errorf("track %d is not valid", i+1)
+				}, fmt.Errorf("Opus track %d is not valid: %v", i+1, err)
 			}
 		}
 	}


### PR DESCRIPTION
Sample output:
```
2021/11/30 20:34:56 INF [RTSP] [conn 127.0.0.1:38634] closed (H264 track 1 is not valid: sprop-parameter-sets is missing (96 profile-level-id=42e01f;packetization-mode=1))
```