### PR TITLE
Stop generating architecture-specific docker tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,32 +245,20 @@ dockerhub:
 	docker buildx create --name=builder --use
 
 	echo "$$DOCKERFILE_DOCKERHUB" | docker buildx build . -f - --build-arg VERSION=$(VERSION) \
-	--push -t aler9/rtsp-simple-server:$(VERSION)-amd64 --build-arg OPTS="GOOS=linux GOARCH=amd64" --platform=linux/amd64
+	-t aler9/rtsp-simple-server:$(VERSION)-amd64 --build-arg OPTS="GOOS=linux GOARCH=amd64" --platform=linux/amd64
 
 	echo "$$DOCKERFILE_DOCKERHUB" | docker buildx build . -f - --build-arg VERSION=$(VERSION) \
-	--push -t aler9/rtsp-simple-server:$(VERSION)-armv6 --build-arg OPTS="GOOS=linux GOARCH=arm GOARM=6" --platform=linux/arm/v6
+	-t aler9/rtsp-simple-server:$(VERSION)-armv6 --build-arg OPTS="GOOS=linux GOARCH=arm GOARM=6" --platform=linux/arm/v6
 
 	echo "$$DOCKERFILE_DOCKERHUB" | docker buildx build . -f - --build-arg VERSION=$(VERSION) \
-	--push -t aler9/rtsp-simple-server:$(VERSION)-armv7 --build-arg OPTS="GOOS=linux GOARCH=arm GOARM=7" --platform=linux/arm/v7
+	-t aler9/rtsp-simple-server:$(VERSION)-armv7 --build-arg OPTS="GOOS=linux GOARCH=arm GOARM=7" --platform=linux/arm/v7
 
 	echo "$$DOCKERFILE_DOCKERHUB" | docker buildx build . -f - --build-arg VERSION=$(VERSION) \
-	--push -t aler9/rtsp-simple-server:$(VERSION)-arm64v8 --build-arg OPTS="GOOS=linux GOARCH=arm64" --platform=linux/arm64/v8
+	-t aler9/rtsp-simple-server:$(VERSION)-arm64v8 --build-arg OPTS="GOOS=linux GOARCH=arm64" --platform=linux/arm64/v8
 
 	docker manifest create aler9/rtsp-simple-server:$(VERSION) \
 	$(foreach ARCH,amd64 armv6 armv7 arm64v8,aler9/rtsp-simple-server:$(VERSION)-$(ARCH))
 	docker manifest push aler9/rtsp-simple-server:$(VERSION)
-
-	docker manifest create aler9/rtsp-simple-server:latest-amd64 aler9/rtsp-simple-server:$(VERSION)-amd64
-	docker manifest push aler9/rtsp-simple-server:latest-amd64
-
-	docker manifest create aler9/rtsp-simple-server:latest-armv6 aler9/rtsp-simple-server:$(VERSION)-armv6
-	docker manifest push aler9/rtsp-simple-server:latest-armv6
-
-	docker manifest create aler9/rtsp-simple-server:latest-armv7 aler9/rtsp-simple-server:$(VERSION)-armv7
-	docker manifest push aler9/rtsp-simple-server:latest-armv7
-
-	docker manifest create aler9/rtsp-simple-server:latest-arm64v8 aler9/rtsp-simple-server:$(VERSION)-arm64v8
-	docker manifest push aler9/rtsp-simple-server:latest-arm64v8
 
 	docker manifest create aler9/rtsp-simple-server:latest \
 	$(foreach ARCH,amd64 armv6 armv7 arm64v8,aler9/rtsp-simple-server:$(VERSION)-$(ARCH))


### PR DESCRIPTION
Docker >= 20.10.0 has a new flag that allows to pull images of a
specific architecture; i.e:

docker pull --platform=linux/arm/v8 aler9/rtsp-simple-server:0.0.0

Image tags like "0.0.0-arm64" allowed to pull images of a specific
architecture before the introduction of the flag, and are not necessary
anymore.