### PR TITLE
api, metrics: add number of bytes received and sent from/to all entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Full documentation of the API is available on the [dedicated site](https://aler9
 
 ### Metrics
 
-A metrics exporter, compatible with Prometheus, can be enabled with the parameter `metrics: yes`; then the server can be queried for metrics with Prometheus or with a simple HTTP request:
+A metrics exporter, compatible with [Prometheus](https://prometheus.io/), can be enabled with the parameter `metrics: yes`; then the server can be queried for metrics with Prometheus or with a simple HTTP request:
 
 ```
 wget -qO- localhost:9998/metrics
@@ -441,49 +441,40 @@ wget -qO- localhost:9998/metrics
 
 Obtaining:
 
-```
+```ini
+# metrics of every path
 paths{name="[path_name]",state="[state]"} 1
-paths_bytes_received{name="[path_name]"} 1234
+paths_bytes_received{name="[path_name]",state="[state]"} 1234
+
+# metrics of every RTSP connection
 rtsp_conns{id="[id]"} 1
 rtsp_conns_bytes_received{id="[id]"} 1234
 rtsp_conns_bytes_sent{id="[id]"} 187
+
+# metrics of every RTSP session
 rtsp_sessions{id="[id]",state="idle"} 1
-rtsp_sessions_bytes_received{id="[id]"} 1234
-rtsp_sessions_bytes_sent{id="[id]"} 187
+rtsp_sessions_bytes_received{id="[id]",state="[state]"} 1234
+rtsp_sessions_bytes_sent{id="[id]",state="[state]"} 187
+
+# metrics of every RTSPS connection
 rtsps_conns{id="[id]"} 1
 rtsps_conns_bytes_received{id="[id]"} 1234
 rtsps_conns_bytes_sent{id="[id]"} 187
+
+# metrics of every RTSPS session
 rtsps_sessions{id="[id]",state="[state]"} 1
-rtsps_sessions_bytes_received{id="[id]"} 1234
-rtsps_sessions_bytes_sent{id="[id]"} 187
+rtsps_sessions_bytes_received{id="[id]",state="[state]"} 1234
+rtsps_sessions_bytes_sent{id="[id]",state="[state]"} 187
+
+# metrics of every RTMP connection
 rtmp_conns{id="[id]",state="[state]"} 1
-rtmp_conns_bytes_received{id="[id]"} 1234
-rtmp_conns_bytes_sent{id="[id]"} 187
+rtmp_conns_bytes_received{id="[id]",state="[state]"} 1234
+rtmp_conns_bytes_sent{id="[id]",state="[state]"} 187
+
+# metrics of every HLS muxer
 hls_muxers{name="[name]"} 1
 hls_muxers_bytes_sent{name="[name]"} 187
 ```
-
-where:
-
-* `paths{name="[path_name]",state="[state]"} 1` is replicated for each path and provides the name and state of the path
-* `paths_bytes_received{name="[path_name]"} 1234` is replicated for each path and provides the number of bytes received by the path from its source
-* `rtsp_conns{id="[id]"}` is replicated for each RTSP connection and provides the ID of the connection
-* `rtsp_conns_bytes_received{id="[id]"}` is replicated for each RTSP connection and provides the number of bytes received from the connection
-* `rtsp_conns_bytes_sent{id="[id]"}` is replicated for each RTSP connection and provides the number of bytes sent to the connection
-* `rtsp_sessions{id="[id]",state="[state]"} 1` is replicated for each RTSP session and provides the ID and state of the session
-* `rtsp_sessions_bytes_received{id="[id]"} 1234` is replicated for each RTSP session and provides the number of bytes received from the session
-* `rtsp_sessions_bytes_sent{id="[id]"} 187` is replicated for each RTSP session and provides the number of bytes sent from the session
-* `rtsp_conns{id="[id]"}` is replicated for each RTSPS connection and provides the ID of the connection
-* `rtsp_conns_bytes_received{id="[id]"}` is replicated for each RTSPS connection and provides the number of bytes received from the connection
-* `rtsp_conns_bytes_sent{id="[id]"}` is replicated for each RTSPS connection and provides the number of bytes sent to the connection
-* `rtsps_sessions{id="[id]",state="[state]"} 1` is replicated for each RTSPS session and provides the ID and state of the session
-* `rtsps_sessions_bytes_received{id="[id]"} 1234` is replicated for each RTSPS session and provides the number of bytes received from the session
-* `rtsps_sessions_bytes_sent{id="[id]"} 187` is replicated for each RTSPS session and provides the number of bytes sent from the session
-* `rtmp_conns{id="[id]",state="[state]"} 1}` is replicated for each RTMP connection and provides the ID and state of the connection
-* `rtmp_conns_bytes_received{id="[id]"} 1234` is replicated for each RTMP connection and provides the number of bytes received from the connection
-* `rtmp_conns_bytes_sent{id="[id]"} 187` is replicated for each RTMP connection and provides the number of bytes sent to the session
-* `hls_muxers{name="[name]"}` is replicated for each HLS muxer and provides the name and state of every HLS muxer
-* `hls_muxers_bytes_sent{name="[name]"} 187` is replicated for each HLS muxer and provides the number of bytes sent by the muxer through HTTP
 
 ### pprof
 

--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ rtsp_conns 1
 rtsp_sessions{state="idle"} 0
 rtsp_sessions{state="read"} 0
 rtsp_sessions{state="publish"} 1
+rtsps_conns 1
 rtsps_sessions{state="idle"} 0
 rtsps_sessions{state="read"} 0
 rtsps_sessions{state="publish"} 0
@@ -459,9 +460,11 @@ hls_muxers{name="<name>"} 1
 where:
 
 * `paths{name="<path_name>",state="ready"} 1` is replicated for every path and shows the name and state of every path
+* `rtsp_conns` is the count of RTSP connections
 * `rtsp_sessions{state="idle"}` is the count of RTSP sessions that are idle
 * `rtsp_sessions{state="read"}` is the count of RTSP sessions that are reading
 * `rtsp_sessions{state="publish"}` is the counf ot RTSP sessions that are publishing
+* `rtsps_conns` is the count of RTSPS connections
 * `rtsps_sessions{state="idle"}` is the count of RTSPS sessions that are idle
 * `rtsps_sessions{state="read"}` is the count of RTSPS sessions that are reading
 * `rtsps_sessions{state="publish"}` is the counf ot RTSPS sessions that are publishing

--- a/README.md
+++ b/README.md
@@ -442,36 +442,48 @@ wget -qO- localhost:9998/metrics
 Obtaining:
 
 ```
-paths{name="<path_name>",state="ready"} 1
-rtsp_conns 1
-rtsp_sessions{state="idle"} 0
-rtsp_sessions{state="read"} 0
-rtsp_sessions{state="publish"} 1
-rtsps_conns 1
-rtsps_sessions{state="idle"} 0
-rtsps_sessions{state="read"} 0
-rtsps_sessions{state="publish"} 0
-rtmp_conns{state="idle"} 0
-rtmp_conns{state="read"} 0
-rtmp_conns{state="publish"} 1
-hls_muxers{name="<name>"} 1
+paths{name="[path_name]",state="[state]"} 1
+paths_bytes_received{name="[path_name]"} 1234
+rtsp_conns{id="[id]"} 1
+rtsp_conns_bytes_received{id="[id]"} 1234
+rtsp_conns_bytes_sent{id="[id]"} 187
+rtsp_sessions{id="[id]",state="idle"} 1
+rtsp_sessions_bytes_received{id="[id]"} 1234
+rtsp_sessions_bytes_sent{id="[id]"} 187
+rtsps_conns{id="[id]"} 1
+rtsps_conns_bytes_received{id="[id]"} 1234
+rtsps_conns_bytes_sent{id="[id]"} 187
+rtsps_sessions{id="[id]",state="[state]"} 1
+rtsps_sessions_bytes_received{id="[id]"} 1234
+rtsps_sessions_bytes_sent{id="[id]"} 187
+rtmp_conns{id="[id]",state="[state]"} 1
+rtmp_conns_bytes_received{id="[id]"} 1234
+rtmp_conns_bytes_sent{id="[id]"} 187
+hls_muxers{name="[name]"} 1
+hls_muxers_bytes_sent{name="[name]"} 187
 ```
 
 where:
 
-* `paths{name="<path_name>",state="ready"} 1` is replicated for every path and shows the name and state of every path
-* `rtsp_conns` is the count of RTSP connections
-* `rtsp_sessions{state="idle"}` is the count of RTSP sessions that are idle
-* `rtsp_sessions{state="read"}` is the count of RTSP sessions that are reading
-* `rtsp_sessions{state="publish"}` is the counf ot RTSP sessions that are publishing
-* `rtsps_conns` is the count of RTSPS connections
-* `rtsps_sessions{state="idle"}` is the count of RTSPS sessions that are idle
-* `rtsps_sessions{state="read"}` is the count of RTSPS sessions that are reading
-* `rtsps_sessions{state="publish"}` is the counf ot RTSPS sessions that are publishing
-* `rtmp_conns{state="idle"}` is the count of RTMP connections that are idle
-* `rtmp_conns{state="read"}` is the count of RTMP connections that are reading
-* `rtmp_conns{state="publish"}` is the count of RTMP connections that are publishing
-* `hls_muxers{name="<name>"}` is replicated for every HLS muxer and shows the name and state of every HLS muxer
+* `paths{name="[path_name]",state="[state]"} 1` is replicated for each path and provides the name and state of the path
+* `paths_bytes_received{name="[path_name]"} 1234` is replicated for each path and provides the number of bytes received by the path from its source
+* `rtsp_conns{id="[id]"}` is replicated for each RTSP connection and provides the ID of the connection
+* `rtsp_conns_bytes_received{id="[id]"}` is replicated for each RTSP connection and provides the number of bytes received from the connection
+* `rtsp_conns_bytes_sent{id="[id]"}` is replicated for each RTSP connection and provides the number of bytes sent to the connection
+* `rtsp_sessions{id="[id]",state="[state]"} 1` is replicated for each RTSP session and provides the ID and state of the session
+* `rtsp_sessions_bytes_received{id="[id]"} 1234` is replicated for each RTSP session and provides the number of bytes received from the session
+* `rtsp_sessions_bytes_sent{id="[id]"} 187` is replicated for each RTSP session and provides the number of bytes sent from the session
+* `rtsp_conns{id="[id]"}` is replicated for each RTSPS connection and provides the ID of the connection
+* `rtsp_conns_bytes_received{id="[id]"}` is replicated for each RTSPS connection and provides the number of bytes received from the connection
+* `rtsp_conns_bytes_sent{id="[id]"}` is replicated for each RTSPS connection and provides the number of bytes sent to the connection
+* `rtsps_sessions{id="[id]",state="[state]"} 1` is replicated for each RTSPS session and provides the ID and state of the session
+* `rtsps_sessions_bytes_received{id="[id]"} 1234` is replicated for each RTSPS session and provides the number of bytes received from the session
+* `rtsps_sessions_bytes_sent{id="[id]"} 187` is replicated for each RTSPS session and provides the number of bytes sent from the session
+* `rtmp_conns{id="[id]",state="[state]"} 1}` is replicated for each RTMP connection and provides the ID and state of the connection
+* `rtmp_conns_bytes_received{id="[id]"} 1234` is replicated for each RTMP connection and provides the number of bytes received from the connection
+* `rtmp_conns_bytes_sent{id="[id]"} 187` is replicated for each RTMP connection and provides the number of bytes sent to the session
+* `hls_muxers{name="[name]"}` is replicated for each HLS muxer and provides the name and state of every HLS muxer
+* `hls_muxers_bytes_sent{name="[name]"} 187` is replicated for each HLS muxer and provides the number of bytes sent by the muxer through HTTP
 
 ### pprof
 

--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -382,11 +382,9 @@ components:
           type: string
         remoteAddr:
           type: string
-        received:
-          description: number of bytes received.
+        bytesReceived:
           type: number
-        sent:
-          description: number of bytes sent.
+        bytesSent:
           type: number
 
     RTSPSession:
@@ -399,11 +397,9 @@ components:
         state:
           type: string
           enum: [idle, read, publish]
-        received:
-          description: number of bytes received.
+        bytesReceived:
           type: number
-        sent:
-          description: number of bytes sent.
+        bytesSent:
           type: number
 
     RTMPConn:
@@ -416,11 +412,9 @@ components:
         state:
           type: string
           enum: [idle, read, publish]
-        received:
-          description: number of bytes received.
+        bytesReceived:
           type: number
-        sent:
-          description: number of bytes sent.
+        bytesSent:
           type: number
 
     HLSMuxer:
@@ -430,6 +424,8 @@ components:
           type: string
         lastRequest:
           type: string
+        bytesSent:
+          type: number
 
     PathsList:
       type: object

--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -268,6 +268,8 @@ components:
             - PCMU
             - VP8
             - VP9
+        bytesReceived:
+          type: number
         readers:
           type: array
           items:
@@ -587,7 +589,7 @@ paths:
   /v1/paths/list:
     get:
       operationId: pathsList
-      summary: returns all active paths.
+      summary: returns all paths.
       description: ''
       responses:
         '200':
@@ -604,7 +606,7 @@ paths:
   /v1/rtspconns/list:
     get:
       operationId: rtspConnsList
-      summary: returns all active RTSP connections.
+      summary: returns all RTSP connections.
       description: ''
       responses:
         '200':
@@ -621,7 +623,7 @@ paths:
   /v1/rtspsessions/list:
     get:
       operationId: rtspSessionsList
-      summary: returns all active RTSP sessions.
+      summary: returns all RTSP sessions.
       description: ''
       responses:
         '200':
@@ -638,7 +640,7 @@ paths:
   /v1/rtspsconns/list:
     get:
       operationId: rtspsConnsList
-      summary: returns all active RTSPS connections.
+      summary: returns all RTSPS connections.
       description: ''
       responses:
         '200':
@@ -675,7 +677,7 @@ paths:
   /v1/rtspssessions/list:
     get:
       operationId: rtspsSessionsList
-      summary: returns all active RTSPS sessions.
+      summary: returns all RTSPS sessions.
       description: ''
       responses:
         '200':
@@ -712,7 +714,7 @@ paths:
   /v1/rtmpconns/list:
     get:
       operationId: rtmpConnsList
-      summary: returns all active RTMP connections.
+      summary: returns all RTMP connections.
       description: ''
       responses:
         '200':
@@ -749,7 +751,7 @@ paths:
   /v1/rtmpsconns/list:
     get:
       operationId: rtmpsConnsList
-      summary: returns all active RTMPS connections.
+      summary: returns all RTMPS connections.
       description: ''
       responses:
         '200':
@@ -786,7 +788,7 @@ paths:
   /v1/hlsmuxers/list:
     get:
       operationId: hlsMuxersList
-      summary: returns all active HLS muxers.
+      summary: returns all HLS muxers.
       description: ''
       responses:
         '200':

--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -416,6 +416,12 @@ components:
         state:
           type: string
           enum: [idle, read, publish]
+        received:
+          description: number of bytes received.
+          type: number
+        sent:
+          description: number of bytes sent.
+          type: number
 
     HLSMuxer:
       type: object

--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -382,6 +382,12 @@ components:
           type: string
         remoteAddr:
           type: string
+        received:
+          description: number of bytes received.
+          type: number
+        sent:
+          description: number of bytes sent.
+          type: number
 
     RTSPSession:
       type: object
@@ -393,19 +399,14 @@ components:
         state:
           type: string
           enum: [idle, read, publish]
+        received:
+          description: number of bytes received.
+          type: number
+        sent:
+          description: number of bytes sent.
+          type: number
 
     RTMPConn:
-      type: object
-      properties:
-        created:
-          type: string
-        remoteAddr:
-          type: string
-        state:
-          type: string
-          enum: [idle, read, publish]
-
-    RTMPSConn:
       type: object
       properties:
         created:
@@ -463,14 +464,6 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/RTMPConn'
-
-    RTMPSConnsList:
-      type: object
-      properties:
-        items:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/RTMPSConn'
 
     HLSMuxersList:
       type: object
@@ -762,7 +755,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RTMPSConnsList'
+                $ref: '#/components/schemas/RTMPConnsList'
         '400':
           description: invalid request.
         '500':

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/abema/go-mp4 v0.8.0
-	github.com/aler9/gortsplib v0.0.0-20221105162652-b1ed0a8abb48
+	github.com/aler9/gortsplib v0.0.0-20221109182805-d75423d18594
 	github.com/asticode/go-astits v1.10.1-0.20220319093903-4abe66a9b757
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gin-gonic/gin v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/abema/go-mp4 v0.8.0
-	github.com/aler9/gortsplib v0.0.0-20221109182805-d75423d18594
+	github.com/aler9/gortsplib v0.0.0-20221110211534-12c8845fef0d
 	github.com/asticode/go-astits v1.10.1-0.20220319093903-4abe66a9b757
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gin-gonic/gin v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/aler9/gortsplib v0.0.0-20221109182805-d75423d18594 h1:q4JKFPTLZLBTeR/EVErmta3Kb783t97ihEPH+y/lWlQ=
-github.com/aler9/gortsplib v0.0.0-20221109182805-d75423d18594/go.mod h1:BOWNZ/QBkY/eVcRqUzJbPFEsRJshwxaxBT01K260Jeo=
+github.com/aler9/gortsplib v0.0.0-20221110211534-12c8845fef0d h1:fRx79L1YMXaoiSMkB32xgVCUMbOcmQ4JfySaUv7XZpc=
+github.com/aler9/gortsplib v0.0.0-20221110211534-12c8845fef0d/go.mod h1:BOWNZ/QBkY/eVcRqUzJbPFEsRJshwxaxBT01K260Jeo=
 github.com/aler9/writerseeker v0.0.0-20220601075008-6f0e685b9c82 h1:9WgSzBLo3a9ToSVV7sRTBYZ1GGOZUpq4+5H3SN0UZq4=
 github.com/aler9/writerseeker v0.0.0-20220601075008-6f0e685b9c82/go.mod h1:qsMrZCbeBf/mCLOeF16KDkPu4gktn/pOWyaq1aYQE7U=
 github.com/asticode/go-astikit v0.20.0 h1:+7N+J4E4lWx2QOkRdOf6DafWJMv6O4RRfgClwQokrH8=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/aler9/gortsplib v0.0.0-20221105162652-b1ed0a8abb48 h1:SVcUqrsR+RXT8cxopOahKQaj8kb02adaEeRexLLKcMc=
-github.com/aler9/gortsplib v0.0.0-20221105162652-b1ed0a8abb48/go.mod h1:BOWNZ/QBkY/eVcRqUzJbPFEsRJshwxaxBT01K260Jeo=
+github.com/aler9/gortsplib v0.0.0-20221109182805-d75423d18594 h1:q4JKFPTLZLBTeR/EVErmta3Kb783t97ihEPH+y/lWlQ=
+github.com/aler9/gortsplib v0.0.0-20221109182805-d75423d18594/go.mod h1:BOWNZ/QBkY/eVcRqUzJbPFEsRJshwxaxBT01K260Jeo=
 github.com/aler9/writerseeker v0.0.0-20220601075008-6f0e685b9c82 h1:9WgSzBLo3a9ToSVV7sRTBYZ1GGOZUpq4+5H3SN0UZq4=
 github.com/aler9/writerseeker v0.0.0-20220601075008-6f0e685b9c82/go.mod h1:qsMrZCbeBf/mCLOeF16KDkPu4gktn/pOWyaq1aYQE7U=
 github.com/asticode/go-astikit v0.20.0 h1:+7N+J4E4lWx2QOkRdOf6DafWJMv6O4RRfgClwQokrH8=

--- a/internal/core/hls_muxer.go
+++ b/internal/core/hls_muxer.go
@@ -138,7 +138,7 @@ type hlsMuxer struct {
 	lastRequestTime *int64
 	muxer           *hls.Muxer
 	requests        []*hlsMuxerRequest
-	bytesSent       uint64
+	bytesSent       *uint64
 
 	// in
 	chRequest          chan *hlsMuxerRequest
@@ -185,6 +185,7 @@ func newHLSMuxer(
 			v := time.Now().UnixNano()
 			return &v
 		}(),
+		bytesSent:          new(uint64),
 		chRequest:          make(chan *hlsMuxerRequest),
 		chAPIHLSMuxersList: make(chan hlsServerAPIMuxersListSubReq),
 	}
@@ -253,7 +254,7 @@ func (m *hlsMuxer) run() {
 				req.data.Items[m.name] = hlsServerAPIMuxersListItem{
 					Created:     m.created,
 					LastRequest: time.Unix(0, atomic.LoadInt64(m.lastRequestTime)),
-					BytesSent:   atomic.LoadUint64(&m.bytesSent),
+					BytesSent:   atomic.LoadUint64(m.bytesSent),
 				}
 				close(req.res)
 
@@ -564,7 +565,7 @@ func (m *hlsMuxer) authenticate(ctx *gin.Context) error {
 }
 
 func (m *hlsMuxer) addSentBytes(n uint64) {
-	atomic.AddUint64(&m.bytesSent, n)
+	atomic.AddUint64(m.bytesSent, n)
 }
 
 // request is called by hlsserver.Server (forwarded from ServeHTTP).

--- a/internal/core/hls_muxer.go
+++ b/internal/core/hls_muxer.go
@@ -94,11 +94,16 @@ window.addEventListener('DOMContentLoaded', create);
 </html>
 `
 
+type hlsMuxerResponse struct {
+	muxer *hlsMuxer
+	cb    func() *hls.MuxerFileResponse
+}
+
 type hlsMuxerRequest struct {
 	dir  string
 	file string
 	ctx  *gin.Context
-	res  chan func() *hls.MuxerFileResponse
+	res  chan hlsMuxerResponse
 }
 
 type hlsMuxerPathManager interface {
@@ -133,6 +138,7 @@ type hlsMuxer struct {
 	lastRequestTime *int64
 	muxer           *hls.Muxer
 	requests        []*hlsMuxerRequest
+	bytesSent       uint64
 
 	// in
 	chRequest          chan *hlsMuxerRequest
@@ -235,7 +241,10 @@ func (m *hlsMuxer) run() {
 
 			case req := <-m.chRequest:
 				if isReady {
-					req.res <- m.handleRequest(req)
+					req.res <- hlsMuxerResponse{
+						muxer: m,
+						cb:    m.handleRequest(req),
+					}
 				} else {
 					m.requests = append(m.requests, req)
 				}
@@ -244,13 +253,17 @@ func (m *hlsMuxer) run() {
 				req.data.Items[m.name] = hlsServerAPIMuxersListItem{
 					Created:     m.created,
 					LastRequest: time.Unix(0, atomic.LoadInt64(m.lastRequestTime)),
+					BytesSent:   atomic.LoadUint64(&m.bytesSent),
 				}
 				close(req.res)
 
 			case <-innerReady:
 				isReady = true
 				for _, req := range m.requests {
-					req.res <- m.handleRequest(req)
+					req.res <- hlsMuxerResponse{
+						muxer: m,
+						cb:    m.handleRequest(req),
+					}
 				}
 				m.requests = nil
 
@@ -264,8 +277,11 @@ func (m *hlsMuxer) run() {
 	m.ctxCancel()
 
 	for _, req := range m.requests {
-		req.res <- func() *hls.MuxerFileResponse {
-			return &hls.MuxerFileResponse{Status: http.StatusNotFound}
+		req.res <- hlsMuxerResponse{
+			muxer: m,
+			cb: func() *hls.MuxerFileResponse {
+				return &hls.MuxerFileResponse{Status: http.StatusNotFound}
+			},
 		}
 	}
 
@@ -547,13 +563,20 @@ func (m *hlsMuxer) authenticate(ctx *gin.Context) error {
 	return nil
 }
 
+func (m *hlsMuxer) addSentBytes(n uint64) {
+	atomic.AddUint64(&m.bytesSent, n)
+}
+
 // request is called by hlsserver.Server (forwarded from ServeHTTP).
 func (m *hlsMuxer) request(req *hlsMuxerRequest) {
 	select {
 	case m.chRequest <- req:
 	case <-m.ctx.Done():
-		req.res <- func() *hls.MuxerFileResponse {
-			return &hls.MuxerFileResponse{Status: http.StatusInternalServerError}
+		req.res <- hlsMuxerResponse{
+			muxer: m,
+			cb: func() *hls.MuxerFileResponse {
+				return &hls.MuxerFileResponse{Status: http.StatusInternalServerError}
+			},
 		}
 	}
 }

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -101,8 +101,9 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 				state = "notReady"
 			}
 
-			out += metric("paths{name=\""+name+"\",state=\""+state+"\"}", 1)
-			out += metric("paths_bytes_received{name=\""+name+"\"}", int64(i.BytesReceived))
+			tags := "{name=\"" + name + "\",state=\"" + state + "\"}"
+			out += metric("paths"+tags, 1)
+			out += metric("paths_bytes_received"+tags, int64(i.BytesReceived))
 		}
 	}
 
@@ -111,9 +112,10 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 			res := m.rtspServer.apiConnsList()
 			if res.err == nil {
 				for id, i := range res.data.Items {
-					out += metric("rtsp_conns{id=\""+id+"\"}", 1)
-					out += metric("rtsp_conns_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
-					out += metric("rtsp_conns_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
+					tags := "{id=\"" + id + "\"}"
+					out += metric("rtsp_conns"+tags, 1)
+					out += metric("rtsp_conns_bytes_received"+tags, int64(i.BytesReceived))
+					out += metric("rtsp_conns_bytes_sent"+tags, int64(i.BytesSent))
 				}
 			}
 		}()
@@ -122,9 +124,10 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 			res := m.rtspServer.apiSessionsList()
 			if res.err == nil {
 				for id, i := range res.data.Items {
-					out += metric("rtsp_sessions{id=\""+id+"\",state=\""+i.State+"\"}", 1)
-					out += metric("rtsp_sessions_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
-					out += metric("rtsp_sessions_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
+					tags := "{id=\"" + id + "\",state=\"" + i.State + "\"}"
+					out += metric("rtsp_sessions"+tags, 1)
+					out += metric("rtsp_sessions_bytes_received"+tags, int64(i.BytesReceived))
+					out += metric("rtsp_sessions_bytes_sent"+tags, int64(i.BytesSent))
 				}
 			}
 		}()
@@ -135,9 +138,10 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 			res := m.rtspsServer.apiConnsList()
 			if res.err == nil {
 				for id, i := range res.data.Items {
-					out += metric("rtsps_conns{id=\""+id+"\"}", 1)
-					out += metric("rtsps_conns_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
-					out += metric("rtsps_conns_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
+					tags := "{id=\"" + id + "\"}"
+					out += metric("rtsps_conns"+tags, 1)
+					out += metric("rtsps_conns_bytes_received"+tags, int64(i.BytesReceived))
+					out += metric("rtsps_conns_bytes_sent"+tags, int64(i.BytesSent))
 				}
 			}
 		}()
@@ -146,9 +150,10 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 			res := m.rtspsServer.apiSessionsList()
 			if res.err == nil {
 				for id, i := range res.data.Items {
-					out += metric("rtsps_sessions{id=\""+id+"\",state=\""+i.State+"\"}", 1)
-					out += metric("rtsps_sessions_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
-					out += metric("rtsps_sessions_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
+					tags := "{id=\"" + id + "\",state=\"" + i.State + "\"}"
+					out += metric("rtsps_sessions"+tags, 1)
+					out += metric("rtsps_sessions_bytes_received"+tags, int64(i.BytesReceived))
+					out += metric("rtsps_sessions_bytes_sent"+tags, int64(i.BytesSent))
 				}
 			}
 		}()
@@ -158,9 +163,10 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 		res := m.rtmpServer.apiConnsList()
 		if res.err == nil {
 			for id, i := range res.data.Items {
-				out += metric("rtmp_conns{id=\""+id+"\",state=\""+i.State+"\"}", 1)
-				out += metric("rtmp_conns_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
-				out += metric("rtmp_conns_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
+				tags := "{id=\"" + id + "\",state=\"" + i.State + "\"}"
+				out += metric("rtmp_conns"+tags, 1)
+				out += metric("rtmp_conns_bytes_received"+tags, int64(i.BytesReceived))
+				out += metric("rtmp_conns_bytes_sent"+tags, int64(i.BytesSent))
 			}
 		}
 	}
@@ -169,8 +175,9 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 		res := m.hlsServer.apiHLSMuxersList()
 		if res.err == nil {
 			for name, i := range res.data.Items {
-				out += metric("hls_muxers{name=\""+name+"\"}", 1)
-				out += metric("hls_muxers_bytes_sent{name=\""+name+"\"}", int64(i.BytesSent))
+				tags := "{name=\"" + name + "\"}"
+				out += metric("hls_muxers"+tags, 1)
+				out += metric("hls_muxers_bytes_sent"+tags, int64(i.BytesSent))
 			}
 		}
 	}

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -93,83 +93,63 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 
 	res := m.pathManager.apiPathsList()
 	if res.err == nil {
-		for name, p := range res.data.Items {
-			if p.SourceReady {
-				out += metric("paths{name=\""+name+"\",state=\"ready\"}", 1)
+		for name, i := range res.data.Items {
+			var state string
+			if i.SourceReady {
+				state = "ready"
 			} else {
-				out += metric("paths{name=\""+name+"\",state=\"notReady\"}", 1)
+				state = "notReady"
 			}
+
+			out += metric("paths{name=\""+name+"\",state=\""+state+"\"}", 1)
+			out += metric("paths_bytes_received{name=\""+name+"\"}", int64(i.BytesReceived))
 		}
 	}
 
-	if !interfaceIsEmpty(m.rtspServer) {
+	if !interfaceIsEmpty(m.rtspServer) { //nolint:dupl
 		func() {
 			res := m.rtspServer.apiConnsList()
 			if res.err == nil {
-				out += metric("rtsp_conns", int64(len(res.data.Items)))
+				for id, i := range res.data.Items {
+					out += metric("rtsp_conns{id=\""+id+"\"}", 1)
+					out += metric("rtsp_conns_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
+					out += metric("rtsp_conns_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
+				}
 			}
 		}()
 
 		func() {
 			res := m.rtspServer.apiSessionsList()
 			if res.err == nil {
-				idleCount := int64(0)
-				readCount := int64(0)
-				publishCount := int64(0)
-
-				for _, i := range res.data.Items {
-					switch i.State {
-					case "idle":
-						idleCount++
-					case "read":
-						readCount++
-					case "publish":
-						publishCount++
-					}
+				for id, i := range res.data.Items {
+					out += metric("rtsp_sessions{id=\""+id+"\",state=\""+i.State+"\"}", 1)
+					out += metric("rtsp_sessions_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
+					out += metric("rtsp_sessions_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
 				}
-
-				out += metric("rtsp_sessions{state=\"idle\"}",
-					idleCount)
-				out += metric("rtsp_sessions{state=\"read\"}",
-					readCount)
-				out += metric("rtsp_sessions{state=\"publish\"}",
-					publishCount)
 			}
 		}()
 	}
 
-	if !interfaceIsEmpty(m.rtspsServer) {
+	if !interfaceIsEmpty(m.rtspsServer) { //nolint:dupl
 		func() {
 			res := m.rtspsServer.apiConnsList()
 			if res.err == nil {
-				out += metric("rtsps_conns", int64(len(res.data.Items)))
+				for id, i := range res.data.Items {
+					out += metric("rtsps_conns{id=\""+id+"\"}", 1)
+					out += metric("rtsps_conns_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
+					out += metric("rtsps_conns_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
+				}
 			}
 		}()
 
 		func() {
 			res := m.rtspsServer.apiSessionsList()
 			if res.err == nil {
-				idleCount := int64(0)
-				readCount := int64(0)
-				publishCount := int64(0)
-
-				for _, i := range res.data.Items {
-					switch i.State {
-					case "idle":
-						idleCount++
-					case "read":
-						readCount++
-					case "publish":
-						publishCount++
-					}
+				for id, i := range res.data.Items {
+					out += metric("rtsps_sessions{id=\""+id+"\",state=\""+i.State+"\"}", 1)
+					out += metric("rtsps_sessions_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
+					out += metric("rtsps_sessions_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
 				}
-
-				out += metric("rtsps_sessions{state=\"idle\"}",
-					idleCount)
-				out += metric("rtsps_sessions{state=\"read\"}",
-					readCount)
-				out += metric("rtsps_sessions{state=\"publish\"}",
-					publishCount)
 			}
 		}()
 	}
@@ -177,35 +157,20 @@ func (m *metrics) onMetrics(ctx *gin.Context) {
 	if !interfaceIsEmpty(m.rtmpServer) {
 		res := m.rtmpServer.apiConnsList()
 		if res.err == nil {
-			idleCount := int64(0)
-			readCount := int64(0)
-			publishCount := int64(0)
-
-			for _, i := range res.data.Items {
-				switch i.State {
-				case "idle":
-					idleCount++
-				case "read":
-					readCount++
-				case "publish":
-					publishCount++
-				}
+			for id, i := range res.data.Items {
+				out += metric("rtmp_conns{id=\""+id+"\",state=\""+i.State+"\"}", 1)
+				out += metric("rtmp_conns_bytes_received{id=\""+id+"\"}", int64(i.BytesReceived))
+				out += metric("rtmp_conns_bytes_sent{id=\""+id+"\"}", int64(i.BytesSent))
 			}
-
-			out += metric("rtmp_conns{state=\"idle\"}",
-				idleCount)
-			out += metric("rtmp_conns{state=\"read\"}",
-				readCount)
-			out += metric("rtmp_conns{state=\"publish\"}",
-				publishCount)
 		}
 	}
 
 	if !interfaceIsEmpty(m.hlsServer) {
 		res := m.hlsServer.apiHLSMuxersList()
 		if res.err == nil {
-			for name := range res.data.Items {
+			for name, i := range res.data.Items {
 				out += metric("hls_muxers{name=\""+name+"\"}", 1)
+				out += metric("hls_muxers_bytes_sent{name=\""+name+"\"}", int64(i.BytesSent))
 			}
 		}
 	}

--- a/internal/core/metrics_test.go
+++ b/internal/core/metrics_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"crypto/tls"
 	"io"
 	"net"
 	"net/http"
@@ -39,11 +40,16 @@ func TestMetrics(t *testing.T) {
 	}
 
 	source := gortsplib.Client{}
-
 	err = source.StartPublishing("rtsp://localhost:8554/rtsp_path",
 		gortsplib.Tracks{track})
 	require.NoError(t, err)
 	defer source.Close()
+
+	source2 := gortsplib.Client{TLSConfig: &tls.Config{InsecureSkipVerify: true}}
+	err = source2.StartPublishing("rtsps://localhost:8322/rtsps_path",
+		gortsplib.Tracks{track})
+	require.NoError(t, err)
+	defer source2.Close()
 
 	u, err := url.Parse("rtmp://localhost:1935/rtmp_path")
 	require.NoError(t, err)
@@ -92,12 +98,20 @@ func TestMetrics(t *testing.T) {
 			`paths_bytes_received\{name=".*?",state="ready"\} 0`+"\n"+
 			`paths\{name=".*?",state="ready"\} 1`+"\n"+
 			`paths_bytes_received\{name=".*?",state="ready"\} 0`+"\n"+
+			`paths\{name=".*?",state="ready"\} 1`+"\n"+
+			`paths_bytes_received\{name=".*?",state="ready"\} 0`+"\n"+
 			`rtsp_conns\{id=".*?"\} 1`+"\n"+
 			`rtsp_conns_bytes_received\{id=".*?"\} [0-9]+`+"\n"+
 			`rtsp_conns_bytes_sent\{id=".*?"\} [0-9]+`+"\n"+
 			`rtsp_sessions\{id=".*?",state="publish"\} 1`+"\n"+
 			`rtsp_sessions_bytes_received\{id=".*?",state="publish"\} 0`+"\n"+
 			`rtsp_sessions_bytes_sent\{id=".*?",state="publish"\} [0-9]+`+"\n"+
+			`rtsps_conns\{id=".*?"\} 1`+"\n"+
+			`rtsps_conns_bytes_received\{id=".*?"\} [0-9]+`+"\n"+
+			`rtsps_conns_bytes_sent\{id=".*?"\} [0-9]+`+"\n"+
+			`rtsps_sessions\{id=".*?",state="publish"\} 1`+"\n"+
+			`rtsps_sessions_bytes_received\{id=".*?",state="publish"\} 0`+"\n"+
+			`rtsps_sessions_bytes_sent\{id=".*?",state="publish"\} [0-9]+`+"\n"+
 			`rtmp_conns\{id=".*?",state="publish"\} 1`+"\n"+
 			`rtmp_conns_bytes_received\{id=".*?",state="publish"\} [0-9]+`+"\n"+
 			`rtmp_conns_bytes_sent\{id=".*?",state="publish"\} [0-9]+`+"\n"+

--- a/internal/core/metrics_test.go
+++ b/internal/core/metrics_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/aler9/gortsplib"
@@ -88,27 +87,21 @@ func TestMetrics(t *testing.T) {
 	bo, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	vals := make(map[string]string)
-	lines := strings.Split(string(bo), "\n")
-	for _, l := range lines[:len(lines)-1] {
-		fields := strings.Split(l, " ")
-		vals[fields[0]] = fields[1]
-	}
-
-	require.Equal(t, map[string]string{
-		"hls_muxers{name=\"rtsp_path\"}":            "1",
-		"paths{name=\"rtsp_path\",state=\"ready\"}": "1",
-		"paths{name=\"rtmp_path\",state=\"ready\"}": "1",
-		"rtmp_conns{state=\"idle\"}":                "0",
-		"rtmp_conns{state=\"publish\"}":             "1",
-		"rtmp_conns{state=\"read\"}":                "0",
-		"rtsp_conns":                                "1",
-		"rtsp_sessions{state=\"idle\"}":             "0",
-		"rtsp_sessions{state=\"publish\"}":          "1",
-		"rtsp_sessions{state=\"read\"}":             "0",
-		"rtsps_conns":                               "0",
-		"rtsps_sessions{state=\"idle\"}":            "0",
-		"rtsps_sessions{state=\"publish\"}":         "0",
-		"rtsps_sessions{state=\"read\"}":            "0",
-	}, vals)
+	require.Regexp(t,
+		`^paths\{name=".*?",state="ready"\} 1`+"\n"+
+			`paths_bytes_received\{name=".*?"\} 0`+"\n"+
+			`paths\{name=".*?",state="ready"\} 1`+"\n"+
+			`paths_bytes_received\{name=".*?"\} 0`+"\n"+
+			`rtsp_conns\{id=".*?"\} 1`+"\n"+
+			`rtsp_conns_bytes_received\{id=".*?"\} [0-9]+`+"\n"+
+			`rtsp_conns_bytes_sent\{id=".*?"\} [0-9]+`+"\n"+
+			`rtsp_sessions\{id=".*?",state="publish"\} 1`+"\n"+
+			`rtsp_sessions_bytes_received\{id=".*?"\} 0`+"\n"+
+			`rtsp_sessions_bytes_sent\{id=".*?"\} [0-9]+`+"\n"+
+			`rtmp_conns\{id=".*?",state="publish"\} 1`+"\n"+
+			`rtmp_conns_bytes_received\{id=".*?"\} [0-9]+`+"\n"+
+			`rtmp_conns_bytes_sent\{id=".*?"\} [0-9]+`+"\n"+
+			`hls_muxers\{name="rtsp_path"\} 1`+"\n"+
+			`hls_muxers_bytes_sent\{name="rtsp_path"\} [0-9]+`+"\n"+"$",
+		string(bo))
 }

--- a/internal/core/metrics_test.go
+++ b/internal/core/metrics_test.go
@@ -89,18 +89,18 @@ func TestMetrics(t *testing.T) {
 
 	require.Regexp(t,
 		`^paths\{name=".*?",state="ready"\} 1`+"\n"+
-			`paths_bytes_received\{name=".*?"\} 0`+"\n"+
+			`paths_bytes_received\{name=".*?",state="ready"\} 0`+"\n"+
 			`paths\{name=".*?",state="ready"\} 1`+"\n"+
-			`paths_bytes_received\{name=".*?"\} 0`+"\n"+
+			`paths_bytes_received\{name=".*?",state="ready"\} 0`+"\n"+
 			`rtsp_conns\{id=".*?"\} 1`+"\n"+
 			`rtsp_conns_bytes_received\{id=".*?"\} [0-9]+`+"\n"+
 			`rtsp_conns_bytes_sent\{id=".*?"\} [0-9]+`+"\n"+
 			`rtsp_sessions\{id=".*?",state="publish"\} 1`+"\n"+
-			`rtsp_sessions_bytes_received\{id=".*?"\} 0`+"\n"+
-			`rtsp_sessions_bytes_sent\{id=".*?"\} [0-9]+`+"\n"+
+			`rtsp_sessions_bytes_received\{id=".*?",state="publish"\} 0`+"\n"+
+			`rtsp_sessions_bytes_sent\{id=".*?",state="publish"\} [0-9]+`+"\n"+
 			`rtmp_conns\{id=".*?",state="publish"\} 1`+"\n"+
-			`rtmp_conns_bytes_received\{id=".*?"\} [0-9]+`+"\n"+
-			`rtmp_conns_bytes_sent\{id=".*?"\} [0-9]+`+"\n"+
+			`rtmp_conns_bytes_received\{id=".*?",state="publish"\} [0-9]+`+"\n"+
+			`rtmp_conns_bytes_sent\{id=".*?",state="publish"\} [0-9]+`+"\n"+
 			`hls_muxers\{name="rtsp_path"\} 1`+"\n"+
 			`hls_muxers_bytes_sent\{name="rtsp_path"\} [0-9]+`+"\n"+"$",
 		string(bo))

--- a/internal/core/rtmp_server.go
+++ b/internal/core/rtmp_server.go
@@ -17,6 +17,8 @@ type rtmpServerAPIConnsListItem struct {
 	Created    time.Time `json:"created"`
 	RemoteAddr string    `json:"remoteAddr"`
 	State      string    `json:"state"`
+	Received   uint64    `json:"received"`
+	Sent       uint64    `json:"sent"`
 }
 
 type rtmpServerAPIConnsListData struct {
@@ -236,6 +238,8 @@ outer:
 						}
 						return "idle"
 					}(),
+					Received: c.conn.BytesReceived(),
+					Sent:     c.conn.BytesSent(),
 				}
 			}
 

--- a/internal/core/rtmp_server.go
+++ b/internal/core/rtmp_server.go
@@ -14,11 +14,11 @@ import (
 )
 
 type rtmpServerAPIConnsListItem struct {
-	Created    time.Time `json:"created"`
-	RemoteAddr string    `json:"remoteAddr"`
-	State      string    `json:"state"`
-	Received   uint64    `json:"received"`
-	Sent       uint64    `json:"sent"`
+	Created       time.Time `json:"created"`
+	RemoteAddr    string    `json:"remoteAddr"`
+	State         string    `json:"state"`
+	BytesReceived uint64    `json:"bytesReceived"`
+	BytesSent     uint64    `json:"bytesSent"`
 }
 
 type rtmpServerAPIConnsListData struct {
@@ -238,8 +238,8 @@ outer:
 						}
 						return "idle"
 					}(),
-					Received: c.conn.BytesReceived(),
-					Sent:     c.conn.BytesSent(),
+					BytesReceived: c.conn.BytesReceived(),
+					BytesSent:     c.conn.BytesSent(),
 				}
 			}
 

--- a/internal/core/rtsp_server.go
+++ b/internal/core/rtsp_server.go
@@ -21,6 +21,8 @@ import (
 type rtspServerAPIConnsListItem struct {
 	Created    time.Time `json:"created"`
 	RemoteAddr string    `json:"remoteAddr"`
+	Received   uint64    `json:"received"`
+	Sent       uint64    `json:"sent"`
 }
 
 type rtspServerAPIConnsListData struct {
@@ -36,6 +38,8 @@ type rtspServerAPISessionsListItem struct {
 	Created    time.Time `json:"created"`
 	RemoteAddr string    `json:"remoteAddr"`
 	State      string    `json:"state"`
+	Received   uint64    `json:"received"`
+	Sent       uint64    `json:"sent"`
 }
 
 type rtspServerAPISessionsListData struct {
@@ -376,6 +380,8 @@ func (s *rtspServer) apiConnsList() rtspServerAPIConnsListRes {
 		data.Items[c.uuid.String()] = rtspServerAPIConnsListItem{
 			Created:    c.created,
 			RemoteAddr: c.remoteAddr().String(),
+			Received:   c.conn.BytesReceived(),
+			Sent:       c.conn.BytesSent(),
 		}
 	}
 
@@ -413,6 +419,8 @@ func (s *rtspServer) apiSessionsList() rtspServerAPISessionsListRes {
 				}
 				return "idle"
 			}(),
+			Received: s.session.BytesReceived(),
+			Sent:     s.session.BytesSent(),
 		}
 	}
 

--- a/internal/core/rtsp_server.go
+++ b/internal/core/rtsp_server.go
@@ -19,10 +19,10 @@ import (
 )
 
 type rtspServerAPIConnsListItem struct {
-	Created    time.Time `json:"created"`
-	RemoteAddr string    `json:"remoteAddr"`
-	Received   uint64    `json:"received"`
-	Sent       uint64    `json:"sent"`
+	Created       time.Time `json:"created"`
+	RemoteAddr    string    `json:"remoteAddr"`
+	BytesReceived uint64    `json:"bytesReceived"`
+	BytesSent     uint64    `json:"bytesSent"`
 }
 
 type rtspServerAPIConnsListData struct {
@@ -35,11 +35,11 @@ type rtspServerAPIConnsListRes struct {
 }
 
 type rtspServerAPISessionsListItem struct {
-	Created    time.Time `json:"created"`
-	RemoteAddr string    `json:"remoteAddr"`
-	State      string    `json:"state"`
-	Received   uint64    `json:"received"`
-	Sent       uint64    `json:"sent"`
+	Created       time.Time `json:"created"`
+	RemoteAddr    string    `json:"remoteAddr"`
+	State         string    `json:"state"`
+	BytesReceived uint64    `json:"bytesReceived"`
+	BytesSent     uint64    `json:"bytesSent"`
 }
 
 type rtspServerAPISessionsListData struct {
@@ -378,10 +378,10 @@ func (s *rtspServer) apiConnsList() rtspServerAPIConnsListRes {
 
 	for _, c := range s.conns {
 		data.Items[c.uuid.String()] = rtspServerAPIConnsListItem{
-			Created:    c.created,
-			RemoteAddr: c.remoteAddr().String(),
-			Received:   c.conn.BytesReceived(),
-			Sent:       c.conn.BytesSent(),
+			Created:       c.created,
+			RemoteAddr:    c.remoteAddr().String(),
+			BytesReceived: c.conn.BytesReceived(),
+			BytesSent:     c.conn.BytesSent(),
 		}
 	}
 
@@ -419,8 +419,8 @@ func (s *rtspServer) apiSessionsList() rtspServerAPISessionsListRes {
 				}
 				return "idle"
 			}(),
-			Received: s.session.BytesReceived(),
-			Sent:     s.session.BytesSent(),
+			BytesReceived: s.session.BytesReceived(),
+			BytesSent:     s.session.BytesSent(),
 		}
 	}
 

--- a/internal/core/streamtrack_h264.go
+++ b/internal/core/streamtrack_h264.go
@@ -70,13 +70,13 @@ type streamTrackH264 struct {
 
 func newStreamTrackH264(
 	track *gortsplib.TrackH264,
-	generateRTPPackets bool,
+	allocateEncoder bool,
 ) *streamTrackH264 {
 	t := &streamTrackH264{
 		track: track,
 	}
 
-	if generateRTPPackets {
+	if allocateEncoder {
 		t.encoder = &rtph264.Encoder{PayloadType: 96}
 		t.encoder.Init()
 	}

--- a/internal/core/streamtrack_mpeg4audio.go
+++ b/internal/core/streamtrack_mpeg4audio.go
@@ -15,13 +15,13 @@ type streamTrackMPEG4Audio struct {
 
 func newStreamTrackMPEG4Audio(
 	track *gortsplib.TrackMPEG4Audio,
-	generateRTPPackets bool,
+	allocateEncoder bool,
 ) *streamTrackMPEG4Audio {
 	t := &streamTrackMPEG4Audio{
 		track: track,
 	}
 
-	if generateRTPPackets {
+	if allocateEncoder {
 		t.encoder = &rtpmpeg4audio.Encoder{
 			PayloadType:      96,
 			SampleRate:       track.ClockRate(),

--- a/internal/rtmp/bytecounter/reader.go
+++ b/internal/rtmp/bytecounter/reader.go
@@ -2,12 +2,13 @@ package bytecounter
 
 import (
 	"io"
+	"sync/atomic"
 )
 
 // Reader allows to count read bytes.
 type Reader struct {
 	r     io.Reader
-	count uint32
+	count uint64
 }
 
 // NewReader allocates a Reader.
@@ -20,16 +21,16 @@ func NewReader(r io.Reader) *Reader {
 // Read implements io.Reader.
 func (r *Reader) Read(p []byte) (int, error) {
 	n, err := r.r.Read(p)
-	r.count += uint32(n)
+	atomic.AddUint64(&r.count, uint64(n))
 	return n, err
 }
 
-// Count returns read bytes.
-func (r Reader) Count() uint32 {
-	return r.count
+// Count returns received bytes.
+func (r *Reader) Count() uint64 {
+	return atomic.LoadUint64(&r.count)
 }
 
 // SetCount sets read bytes.
-func (r *Reader) SetCount(v uint32) {
-	r.count = v
+func (r *Reader) SetCount(v uint64) {
+	atomic.StoreUint64(&r.count, v)
 }

--- a/internal/rtmp/bytecounter/reader.go
+++ b/internal/rtmp/bytecounter/reader.go
@@ -1,42 +1,35 @@
 package bytecounter
 
 import (
-	"bufio"
 	"io"
 )
 
-type readerInner struct {
+// Reader allows to count read bytes.
+type Reader struct {
 	r     io.Reader
 	count uint32
 }
 
-func (r *readerInner) Read(p []byte) (int, error) {
+// NewReader allocates a Reader.
+func NewReader(r io.Reader) *Reader {
+	return &Reader{
+		r: r,
+	}
+}
+
+// Read implements io.Reader.
+func (r *Reader) Read(p []byte) (int, error) {
 	n, err := r.r.Read(p)
 	r.count += uint32(n)
 	return n, err
 }
 
-// Reader allows to count read bytes.
-type Reader struct {
-	ri *readerInner
-	*bufio.Reader
-}
-
-// NewReader allocates a Reader.
-func NewReader(r io.Reader) *Reader {
-	ri := &readerInner{r: r}
-	return &Reader{
-		ri:     ri,
-		Reader: bufio.NewReader(ri),
-	}
-}
-
 // Count returns read bytes.
 func (r Reader) Count() uint32 {
-	return r.ri.count
+	return r.count
 }
 
 // SetCount sets read bytes.
 func (r *Reader) SetCount(v uint32) {
-	r.ri.count = v
+	r.count = v
 }

--- a/internal/rtmp/bytecounter/reader_test.go
+++ b/internal/rtmp/bytecounter/reader_test.go
@@ -19,5 +19,5 @@ func TestReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 64, n)
 
-	require.Equal(t, uint32(100+64), r.Count())
+	require.Equal(t, uint64(100+64), r.Count())
 }

--- a/internal/rtmp/bytecounter/reader_test.go
+++ b/internal/rtmp/bytecounter/reader_test.go
@@ -19,5 +19,5 @@ func TestReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 64, n)
 
-	require.Equal(t, uint32(100+1024), r.Count())
+	require.Equal(t, uint32(100+64), r.Count())
 }

--- a/internal/rtmp/bytecounter/writer.go
+++ b/internal/rtmp/bytecounter/writer.go
@@ -2,12 +2,13 @@ package bytecounter
 
 import (
 	"io"
+	"sync/atomic"
 )
 
 // Writer allows to count written bytes.
 type Writer struct {
 	w     io.Writer
-	count uint32
+	count uint64
 }
 
 // NewWriter allocates a Writer.
@@ -20,16 +21,16 @@ func NewWriter(w io.Writer) *Writer {
 // Write implements io.Writer.
 func (w *Writer) Write(p []byte) (int, error) {
 	n, err := w.w.Write(p)
-	w.count += uint32(n)
+	atomic.AddUint64(&w.count, uint64(n))
 	return n, err
 }
 
-// Count returns written bytes.
-func (w Writer) Count() uint32 {
-	return w.count
+// Count returns sent bytes.
+func (w *Writer) Count() uint64 {
+	return atomic.LoadUint64(&w.count)
 }
 
-// SetCount sets written bytes.
-func (w *Writer) SetCount(v uint32) {
-	w.count = v
+// SetCount sets sent bytes.
+func (w *Writer) SetCount(v uint64) {
+	atomic.StoreUint64(&w.count, v)
 }

--- a/internal/rtmp/bytecounter/writer_test.go
+++ b/internal/rtmp/bytecounter/writer_test.go
@@ -14,5 +14,5 @@ func TestWriter(t *testing.T) {
 	w.SetCount(100)
 
 	w.Write(bytes.Repeat([]byte{0x01}, 64))
-	require.Equal(t, uint32(100+64), w.Count())
+	require.Equal(t, uint64(100+64), w.Count())
 }

--- a/internal/rtmp/conn.go
+++ b/internal/rtmp/conn.go
@@ -119,6 +119,16 @@ func NewConn(rw io.ReadWriter) *Conn {
 	}
 }
 
+// BytesReceived returns the number of bytes received.
+func (c *Conn) BytesReceived() uint64 {
+	return c.bc.Reader.Count()
+}
+
+// BytesSent returns the number of bytes sent.
+func (c *Conn) BytesSent() uint64 {
+	return c.bc.Writer.Count()
+}
+
 func (c *Conn) readCommand() (*message.MsgCommandAMF0, error) {
 	for {
 		msg, err := c.mrw.Read()

--- a/internal/rtmp/conn.go
+++ b/internal/rtmp/conn.go
@@ -114,10 +114,9 @@ type Conn struct {
 
 // NewConn initializes a connection.
 func NewConn(rw io.ReadWriter) *Conn {
-	c := &Conn{}
-	c.bc = bytecounter.NewReadWriter(rw)
-	c.mrw = message.NewReadWriter(c.bc, false)
-	return c
+	return &Conn{
+		bc: bytecounter.NewReadWriter(rw),
+	}
 }
 
 func (c *Conn) readCommand() (*message.MsgCommandAMF0, error) {
@@ -160,6 +159,8 @@ func (c *Conn) InitializeClient(u *url.URL, isPublishing bool) error {
 	if err != nil {
 		return err
 	}
+
+	c.mrw = message.NewReadWriter(c.bc, false)
 
 	err = c.mrw.Write(&message.MsgSetWindowAckSize{
 		Value: 2500000,
@@ -318,6 +319,8 @@ func (c *Conn) InitializeServer() (*url.URL, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+
+	c.mrw = message.NewReadWriter(c.bc, false)
 
 	cmd, err := c.readCommand()
 	if err != nil {

--- a/internal/rtmp/conn_test.go
+++ b/internal/rtmp/conn_test.go
@@ -244,6 +244,14 @@ func TestInitializeClient(t *testing.T) {
 			err = conn.InitializeClient(u, ca == "publish")
 			require.NoError(t, err)
 
+			if ca == "read" {
+				require.Equal(t, uint64(3421), conn.BytesReceived())
+				require.Equal(t, uint64(3409), conn.BytesSent())
+			} else {
+				require.Equal(t, uint64(3427), conn.BytesReceived())
+				require.Equal(t, uint64(3466), conn.BytesSent())
+			}
+
 			<-done
 		})
 	}

--- a/internal/rtmp/rawmessage/reader.go
+++ b/internal/rtmp/rawmessage/reader.go
@@ -30,7 +30,7 @@ func (rc *readerChunkStream) readChunk(c chunk.Chunk, chunkBodySize uint32) erro
 
 	// check if an ack is needed
 	if rc.mr.ackWindowSize != 0 {
-		count := rc.mr.r.Count()
+		count := uint32(rc.mr.r.Count())
 		diff := count - rc.mr.lastAckCount
 
 		if diff > (rc.mr.ackWindowSize) {

--- a/internal/rtmp/rawmessage/reader.go
+++ b/internal/rtmp/rawmessage/reader.go
@@ -1,6 +1,7 @@
 package rawmessage
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"time"
@@ -22,7 +23,7 @@ type readerChunkStream struct {
 }
 
 func (rc *readerChunkStream) readChunk(c chunk.Chunk, chunkBodySize uint32) error {
-	err := c.Read(rc.mr.r, chunkBodySize)
+	err := c.Read(rc.mr.br, chunkBodySize)
 	if err != nil {
 		return err
 	}
@@ -210,6 +211,7 @@ type Reader struct {
 	r           *bytecounter.Reader
 	onAckNeeded func(uint32) error
 
+	br            *bufio.Reader
 	chunkSize     uint32
 	ackWindowSize uint32
 	lastAckCount  uint32
@@ -223,8 +225,11 @@ type Reader struct {
 
 // NewReader allocates a Reader.
 func NewReader(r *bytecounter.Reader, onAckNeeded func(uint32) error) *Reader {
+	br := bufio.NewReader(r)
+
 	return &Reader{
 		r:            r,
+		br:           br,
 		onAckNeeded:  onAckNeeded,
 		chunkSize:    128,
 		chunkStreams: make(map[byte]*readerChunkStream),
@@ -244,7 +249,7 @@ func (r *Reader) SetWindowAckSize(v uint32) {
 // Read reads a Message.
 func (r *Reader) Read() (*Message, error) {
 	for {
-		byt, err := r.r.ReadByte()
+		byt, err := r.br.ReadByte()
 		if err != nil {
 			return nil, err
 		}
@@ -258,7 +263,7 @@ func (r *Reader) Read() (*Message, error) {
 			r.chunkStreams[chunkStreamID] = rc
 		}
 
-		r.r.UnreadByte()
+		r.br.UnreadByte()
 
 		msg, err := rc.readMessage(typ)
 		if err != nil {

--- a/internal/rtmp/rawmessage/reader_test.go
+++ b/internal/rtmp/rawmessage/reader_test.go
@@ -198,8 +198,7 @@ func TestReader(t *testing.T) {
 	for _, ca := range cases {
 		t.Run(ca.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			bcr := bytecounter.NewReader(&buf)
-			r := NewReader(bcr, func(count uint32) error {
+			r := NewReader(bytecounter.NewReader(&buf), func(count uint32) error {
 				return nil
 			})
 
@@ -224,14 +223,14 @@ func TestReaderAcknowledge(t *testing.T) {
 			onAckCalled := make(chan struct{})
 
 			var buf bytes.Buffer
-			bcr := bytecounter.NewReader(&buf)
-			r := NewReader(bcr, func(count uint32) error {
+			bc := bytecounter.NewReader(&buf)
+			r := NewReader(bc, func(count uint32) error {
 				close(onAckCalled)
 				return nil
 			})
 
 			if ca == "overflow" {
-				bcr.SetCount(4294967096)
+				bc.SetCount(4294967096)
 				r.lastAckCount = 4294967096
 			}
 

--- a/internal/rtmp/rawmessage/writer.go
+++ b/internal/rtmp/rawmessage/writer.go
@@ -20,7 +20,7 @@ type writerChunkStream struct {
 func (wc *writerChunkStream) writeChunk(c chunk.Chunk) error {
 	// check if we received an acknowledge
 	if wc.mw.checkAcknowledge && wc.mw.ackWindowSize != 0 {
-		diff := wc.mw.w.Count() - wc.mw.ackValue
+		diff := uint32(wc.mw.w.Count()) - wc.mw.ackValue
 
 		if diff > (wc.mw.ackWindowSize * 3 / 2) {
 			return fmt.Errorf("no acknowledge received within window")


### PR DESCRIPTION
Fixes #734 

TODO:

* [X] API: number of bytes received/sent from/to RTSP connections
* [X] API: number of bytes received/sent from/to RTSP sessions
* [x] API: number of bytes received/sent from/to RTMP connections
* [x] API: number of bytes sent to HLS connections
* [x] API: number of bytes received from paths
* [x] metrics of all the above


