### PR TITLE
rpicamera: fix low framerate when rpiCameraMode is set (#1296)

### DIFF
--- a/internal/rpicamera/exe/parameters.c
+++ b/internal/rpicamera/exe/parameters.c
@@ -82,7 +82,7 @@ bool parameters_load(parameters_t *params) {
         params->level = V4L2_MPEG_VIDEO_H264_LEVEL_4_2;
     }
 
-    params->buffer_count = 3;
+    params->buffer_count = 6;
     params->capture_buffer_count = params->buffer_count * 2;
 
     return true;


### PR DESCRIPTION
Fixes #1296 

In order to read a video frame from libcamera, the read operation has to be requested by using a request.

Each request contains a buffer:

```
request1
- buffer1

request2
- buffer2

request3
- buffer3
```

When `rpiCameraMode` is set, two video streams are initiated, a main one and a secondary one with a greater definition:

```
[0:03:30.432024088] [1253]  INFO Camera camera.cpp:1028 configuring streams: (0) 1920x1080-YUV420 (1) 3840x2160-SRGGB10_CSI2P
```

In this case, each request must contain two buffers in order to read frames from both video streams, even if one of them is not used:

```
request1
- buffer1a
- buffer1b

request2
- buffer2a
- buffer2b

request3
- buffer3a
- buffer3b
```

If the second buffer is not present, libcamera silently creates a buffer during each read operation, significantly decreasing performance.

This PR adds the second buffer to each request.