### PR TITLE
delete existing path onPathClose

### DIFF
--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -379,6 +379,7 @@ func (pm *pathManager) pathSourceNotReady(pa *path) {
 
 // onPathClose is called by path.
 func (pm *pathManager) onPathClose(pa *path) {
+	delete(pm.paths, pa.name)
 	select {
 	case pm.chPathClose <- pa:
 	case <-pm.ctx.Done():


### PR DESCRIPTION
When I try to connect the server on the second time, the connection restart infinitely

https://user-images.githubusercontent.com/55469170/218749217-f2cef095-8e32-40a6-9981-674f7f7767c7.mp4

I find that the paths in the `pathManager`  was not deleted in `onPathClose` , thus not creating new path when I connect on the second time. see https://github.com/aler9/rtsp-simple-server/blob/main/internal/core/path_manager.go#L262-L264

