### PR TITLE
Add option to replace empty path

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -199,6 +199,7 @@ type Conf struct {
 	ServerKey         string      `json:"serverKey"`
 	ServerCert        string      `json:"serverCert"`
 	AuthMethods       AuthMethods `json:"authMethods"`
+	EmptyPathReplace  string      `json:"emptyPathReplace"`
 
 	// RTMP
 	RTMPDisable    bool       `json:"rtmpDisable"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -244,6 +244,7 @@ func (p *Core) createResources(initial bool) error {
 			p.conf.ReadTimeout,
 			p.conf.WriteTimeout,
 			p.conf.ReadBufferCount,
+			p.conf.EmptyPathReplace,
 			p.conf.Paths,
 			p.externalCmdPool,
 			p.metrics,

--- a/rtsp-simple-server.yml
+++ b/rtsp-simple-server.yml
@@ -95,6 +95,8 @@ serverKey: server.key
 serverCert: server.crt
 # Authentication methods.
 authMethods: [basic, digest]
+# If a client requests the empty path, replace with this path name
+emptyPathReplace:
 
 ###############################################
 # RTMP parameters


### PR DESCRIPTION
I have an rtsp client which pulls the stream from the empty path (`rtsp://<ip>/`). I am not happy about this, but I can't change it at this time, so I need rtsp-simple-server to allow this.

To support this without changing a lot of code, I implemented a new config value `emptyPathReplace`, which, when set, the empty path is replaced with. For example when set to `test`, a client requesting `/` sees the stream published to `/test` without knowing anything about the replacement. This works for my use case.

The empty path seems to be nothing completely unknown, VLC for example does support this as a client too.

I know this is a quite special pull request and I am uncertain if this feature is implemented in a good way or even if this should be merged at all. I just wanted to commit this idea in case there are others with this problem. For me, this is currently solved in my fork, so I would be fine with all options:

- You can reject this PR at all if you do not want to support this in rtsp-simple-server, I would not be surprised if there a good reasons against this feature as I don't really like it myself
- You can give me suggestions for a better implementation of this feature (I am not a go developer)
- You can do any changes to my implementation

Thank you!