### PR TITLE
Update OpenAPI schema to use 'integer' data type for input parameter

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -187,11 +187,11 @@ components:
         fallback:
           type: string
         rpiCameraCamID:
-          type: number
+          type: integer
         rpiCameraWidth:
-          type: number
+          type: integer
         rpiCameraHeight:
-          type: number
+          type: integer
         rpiCameraHFlip:
           type: boolean
         rpiCameraVFlip:
@@ -211,7 +211,7 @@ components:
         rpiCameraDenoise:
           type: string
         rpiCameraShutter:
-          type: number
+          type: integer
         rpiCameraMetering:
           type: string
         rpiCameraGain:
@@ -225,11 +225,11 @@ components:
         rpiCameraMode:
           type: string
         rpiCameraFPS:
-          type: number
+          type: integer
         rpiCameraIDRPeriod:
-          type: number
+          type: integer
         rpiCameraBitrate:
-          type: number
+          type: integer
         rpiCameraProfile:
           type: string
         rpiCameraLevel:
@@ -309,7 +309,8 @@ components:
           items:
             type: string
         bytesReceived:
-          type: number
+          type: integer
+          format: int64
         readers:
           type: array
           items:
@@ -445,9 +446,11 @@ components:
         remoteAddr:
           type: string
         bytesReceived:
-          type: number
+          type: integer
+          format: int64
         bytesSent:
-          type: number
+          type: integer
+          format: int64
 
     RTSPSession:
       type: object
@@ -460,9 +463,11 @@ components:
           type: string
           enum: [idle, read, publish]
         bytesReceived:
-          type: number
+          type: integer
+          format: int64
         bytesSent:
-          type: number
+          type: integer
+          format: int64
 
     RTMPConn:
       type: object
@@ -475,9 +480,11 @@ components:
           type: string
           enum: [idle, read, publish]
         bytesReceived:
-          type: number
+          type: integer
+          format: int64
         bytesSent:
-          type: number
+          type: integer
+          format: int64
 
     HLSMuxer:
       type: object
@@ -487,7 +494,8 @@ components:
         lastRequest:
           type: string
         bytesSent:
-          type: number
+          type: integer
+          format: int64
 
     HLSMuxersList:
       type: object
@@ -551,9 +559,11 @@ components:
         remoteCandidate:
           type: string
         bytesReceived:
-          type: number
+          type: integer
+          format: int64
         bytesSent:
-          type: number
+          type: integer
+          format: int64
 
     WebRTCConnsList:
       type: object


### PR DESCRIPTION
Fixes issue #1486 to change the api schema to the correct number type to avoid unexpected behaviour.