### PR TITLE
support reading UDP/MPEG-TS streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Live streams can be published to the server with:
 |RTMP clients (OBS Studio)|RTMP, RTMPS|H264, H265, MPEG4 Audio (AAC)|
 |RTMP servers and cameras|RTMP, RTMPS|H264, MPEG4 Audio (AAC)|
 |HLS servers and cameras|Low-Latency HLS, MP4-based HLS, legacy HLS|H264, H265, MPEG4 Audio (AAC), Opus|
-|UDP/MPEG-TS streams|Unicast, multicast|H264, MPEG4 Audio (AAC)|
+|UDP/MPEG-TS streams|Unicast, broadcast, multicast|H264, H265, MPEG4 Audio (AAC), Opus|
 |Raspberry Pi Cameras||H264|
 
 And can be read from the server with:
@@ -85,6 +85,7 @@ In the next months, the repository name and the docker image name will be change
   * [From a Raspberry Pi Camera](#from-a-raspberry-pi-camera)
   * [From OBS Studio](#from-obs-studio)
   * [From OpenCV](#from-opencv)
+  * [From a UDP stream](#from-a-udp-stream)
 * [Read from the server](#read-from-the-server)
   * [From VLC and Ubuntu](#from-vlc-and-ubuntu)
 * [RTSP protocol](#rtsp-protocol)
@@ -751,6 +752,26 @@ while True:
 
     sleep(1 / fps)
 ```
+
+### From a UDP stream
+
+The server supports ingesting UDP/MPEG-TS packets (i.e. MPEG-TS packets sent with UDP). Packets can be unicast, broadcast or multicast. For instance, you can generate a multicast UDP/MPEG-TS stream with:
+
+```
+gst-launch-1.0 -v mpegtsmux name=mux alignment=1 ! udpsink host=238.0.0.1 port=1234 \
+videotestsrc ! video/x-raw,width=1280,height=720 ! x264enc speed-preset=ultrafast bitrate=6000 key-int-max=40 ! mux. \
+audiotestsrc ! audioconvert ! avenc_aac ! mux.
+```
+
+Edit `rtsp-simple-server.yml` and replace everything inside section `paths` with the following content:
+
+```yml
+paths:
+  udp:
+    source: udp://ip-of-stream:port-of-stream
+```
+
+After starting the server, the stream can be reached on `rtsp://localhost:8554/udp`.
 
 ## Read from the server
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Live streams can be published to the server with:
 |RTMP clients (OBS Studio)|RTMP, RTMPS|H264, H265, MPEG4 Audio (AAC)|
 |RTMP servers and cameras|RTMP, RTMPS|H264, MPEG4 Audio (AAC)|
 |HLS servers and cameras|Low-Latency HLS, MP4-based HLS, legacy HLS|H264, H265, MPEG4 Audio (AAC), Opus|
+|UDP/MPEG-TS streams|Unicast, multicast|H264, MPEG4 Audio (AAC)|
 |Raspberry Pi Cameras||H264|
 
 And can be read from the server with:

--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ Edit `rtsp-simple-server.yml` and replace everything inside section `paths` with
 ```yml
 paths:
   udp:
-    source: udp://ip-of-stream:port-of-stream
+    source: udp://238.0.0.1:1234
 ```
 
 After starting the server, the stream can be reached on `rtsp://localhost:8554/udp`.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/pion/webrtc/v3 v3.1.47
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/crypto v0.5.0
+	golang.org/x/net v0.7.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -63,7 +64,6 @@ require (
 	github.com/ugorji/go/codec v1.2.9 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
-	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/internal/core/hls_source.go
+++ b/internal/core/hls_source.go
@@ -61,14 +61,14 @@ func (s *hlsSource) run(ctx context.Context, cnf *conf.PathConf, reloadConf chan
 				Formats: []format.Format{track},
 			}
 			medias = append(medias, medi)
-			ctrack := track
+			cformat := track
 
 			switch track.(type) {
 			case *format.H264:
 				medi.Type = media.TypeVideo
 
 				c.OnData(track, func(pts time.Duration, unit interface{}) {
-					err := stream.writeData(medi, ctrack, &formatprocessor.UnitH264{
+					err := stream.writeData(medi, cformat, &formatprocessor.UnitH264{
 						PTS: pts,
 						AU:  unit.([][]byte),
 						NTP: time.Now(),
@@ -82,7 +82,7 @@ func (s *hlsSource) run(ctx context.Context, cnf *conf.PathConf, reloadConf chan
 				medi.Type = media.TypeVideo
 
 				c.OnData(track, func(pts time.Duration, unit interface{}) {
-					err := stream.writeData(medi, ctrack, &formatprocessor.UnitH265{
+					err := stream.writeData(medi, cformat, &formatprocessor.UnitH265{
 						PTS: pts,
 						AU:  unit.([][]byte),
 						NTP: time.Now(),
@@ -96,7 +96,7 @@ func (s *hlsSource) run(ctx context.Context, cnf *conf.PathConf, reloadConf chan
 				medi.Type = media.TypeAudio
 
 				c.OnData(track, func(pts time.Duration, unit interface{}) {
-					err := stream.writeData(medi, ctrack, &formatprocessor.UnitMPEG4Audio{
+					err := stream.writeData(medi, cformat, &formatprocessor.UnitMPEG4Audio{
 						PTS: pts,
 						AUs: [][]byte{unit.([]byte)},
 						NTP: time.Now(),
@@ -110,7 +110,7 @@ func (s *hlsSource) run(ctx context.Context, cnf *conf.PathConf, reloadConf chan
 				medi.Type = media.TypeAudio
 
 				c.OnData(track, func(pts time.Duration, unit interface{}) {
-					err := stream.writeData(medi, ctrack, &formatprocessor.UnitOpus{
+					err := stream.writeData(medi, cformat, &formatprocessor.UnitOpus{
 						PTS:   pts,
 						Frame: unit.([]byte),
 						NTP:   time.Now(),

--- a/internal/core/source_static.go
+++ b/internal/core/source_static.go
@@ -81,6 +81,11 @@ func newSourceStatic(
 		s.impl = newHLSSource(
 			s)
 
+	case strings.HasPrefix(cnf.Source, "udp://"):
+		s.impl = newUDPSource(
+			readTimeout,
+			s)
+
 	case cnf.Source == "rpiCamera":
 		s.impl = newRPICameraSource(
 			s)

--- a/internal/core/udp_source.go
+++ b/internal/core/udp_source.go
@@ -1,0 +1,262 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/aler9/gortsplib/v2/pkg/codecs/h264"
+	"github.com/aler9/gortsplib/v2/pkg/codecs/mpeg4audio"
+	"github.com/aler9/gortsplib/v2/pkg/format"
+	"github.com/aler9/gortsplib/v2/pkg/media"
+	"github.com/asticode/go-astits"
+	"golang.org/x/net/ipv4"
+
+	"github.com/aler9/rtsp-simple-server/internal/conf"
+	"github.com/aler9/rtsp-simple-server/internal/formatprocessor"
+	"github.com/aler9/rtsp-simple-server/internal/logger"
+	"github.com/aler9/rtsp-simple-server/internal/mpegts"
+)
+
+const (
+	multicastTTL = 16
+)
+
+type readerFunc func([]byte) (int, error)
+
+func (rf readerFunc) Read(p []byte) (int, error) {
+	return rf(p)
+}
+
+type udpSourceParent interface {
+	log(logger.Level, string, ...interface{})
+	sourceStaticImplSetReady(req pathSourceStaticSetReadyReq) pathSourceStaticSetReadyRes
+	sourceStaticImplSetNotReady(req pathSourceStaticSetNotReadyReq)
+}
+
+type udpSource struct {
+	readTimeout conf.StringDuration
+	parent      udpSourceParent
+}
+
+func newUDPSource(
+	readTimeout conf.StringDuration,
+	parent udpSourceParent,
+) *udpSource {
+	return &udpSource{
+		readTimeout: readTimeout,
+		parent:      parent,
+	}
+}
+
+func (s *udpSource) Log(level logger.Level, format string, args ...interface{}) {
+	s.parent.log(level, "[udp source] "+format, args...)
+}
+
+// run implements sourceStaticImpl.
+func (s *udpSource) run(ctx context.Context, cnf *conf.PathConf, reloadConf chan *conf.PathConf) error {
+	s.Log(logger.Debug, "connecting")
+
+	hostPort := cnf.Source[len("udp://"):]
+
+	pc, err := net.ListenPacket("udp", hostPort)
+	if err != nil {
+		return err
+	}
+	defer pc.Close()
+
+	host, _, _ := net.SplitHostPort(hostPort)
+	ip := net.ParseIP(host)
+
+	if ip.IsMulticast() {
+		p := ipv4.NewPacketConn(pc)
+
+		err = p.SetMulticastTTL(multicastTTL)
+		if err != nil {
+			return err
+		}
+
+		intfs, err := net.Interfaces()
+		if err != nil {
+			return err
+		}
+
+		for _, intf := range intfs {
+			err := p.JoinGroup(&intf, &net.UDPAddr{IP: ip})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	midbuffer := make([]byte, 0, 1472) // UDP MTU
+	midbufferPos := 0
+
+	readPacket := func(buf []byte) (int, error) {
+		if midbufferPos < len(midbuffer) {
+			n := copy(buf, midbuffer[midbufferPos:])
+			midbufferPos += n
+			return n, nil
+		}
+
+		mn, _, err := pc.ReadFrom(midbuffer[:cap(midbuffer)])
+		if err != nil {
+			return 0, err
+		}
+
+		if (mn % 188) != 0 {
+			return 0, fmt.Errorf("received packet with size %d not multiple of 188", mn)
+		}
+
+		midbuffer = midbuffer[:mn]
+		n := copy(buf, midbuffer)
+		midbufferPos = n
+		return n, nil
+	}
+
+	dem := astits.NewDemuxer(
+		context.Background(),
+		readerFunc(readPacket),
+		astits.DemuxerOptPacketSize(188))
+
+	readerErr := make(chan error)
+
+	go func() {
+		readerErr <- func() error {
+			pc.SetReadDeadline(time.Now().Add(time.Duration(s.readTimeout)))
+			tracks, err := mpegts.FindTracks(dem)
+			if err != nil {
+				return err
+			}
+
+			var medias media.Medias
+			mediaCallbacks := make(map[uint16]func(time.Duration, []byte), len(tracks))
+			var stream *stream
+
+			for _, track := range tracks {
+				medi := &media.Media{
+					Formats: []format.Format{track.Format},
+				}
+				medias = append(medias, medi)
+				cformat := track.Format
+
+				switch track.Format.(type) {
+				case *format.H264:
+					medi.Type = media.TypeVideo
+
+					mediaCallbacks[track.ES.ElementaryPID] = func(pts time.Duration, data []byte) {
+						au, err := h264.AnnexBUnmarshal(data)
+						if err != nil {
+							s.Log(logger.Warn, "%v", err)
+							return
+						}
+
+						err = stream.writeData(medi, cformat, &formatprocessor.DataH264{
+							PTS: pts,
+							AU:  au,
+							NTP: time.Now(),
+						})
+						if err != nil {
+							s.Log(logger.Warn, "%v", err)
+						}
+					}
+
+				case *format.MPEG4Audio:
+					medi.Type = media.TypeAudio
+
+					mediaCallbacks[track.ES.ElementaryPID] = func(pts time.Duration, data []byte) {
+						var pkts mpeg4audio.ADTSPackets
+						err := pkts.Unmarshal(data)
+						if err != nil {
+							s.Log(logger.Warn, "%v", err)
+							return
+						}
+
+						aus := make([][]byte, len(pkts))
+						for i, pkt := range pkts {
+							aus[i] = pkt.AU
+						}
+
+						err = stream.writeData(medi, cformat, &formatprocessor.DataMPEG4Audio{
+							PTS: pts,
+							AUs: aus,
+							NTP: time.Now(),
+						})
+						if err != nil {
+							s.Log(logger.Warn, "%v", err)
+						}
+					}
+				}
+			}
+
+			res := s.parent.sourceStaticImplSetReady(pathSourceStaticSetReadyReq{
+				medias:             medias,
+				generateRTPPackets: true,
+			})
+			if res.err != nil {
+				return res.err
+			}
+
+			defer func() {
+				s.parent.sourceStaticImplSetNotReady(pathSourceStaticSetNotReadyReq{})
+			}()
+
+			s.Log(logger.Info, "ready: %s", sourceMediaInfo(medias))
+
+			stream = res.stream
+			var timedec *mpegts.TimeDecoder
+
+			for {
+				pc.SetReadDeadline(time.Now().Add(time.Duration(s.readTimeout)))
+				data, err := dem.NextData()
+				if err != nil {
+					return err
+				}
+
+				if data.PES == nil {
+					continue
+				}
+
+				if data.PES.Header.OptionalHeader == nil ||
+					data.PES.Header.OptionalHeader.PTSDTSIndicator == astits.PTSDTSIndicatorNoPTSOrDTS ||
+					data.PES.Header.OptionalHeader.PTSDTSIndicator == astits.PTSDTSIndicatorIsForbidden {
+					return fmt.Errorf("PTS is missing")
+				}
+
+				var pts time.Duration
+
+				if timedec == nil {
+					timedec = mpegts.NewTimeDecoder(data.PES.Header.OptionalHeader.PTS.Base)
+					pts = 0
+				} else {
+					pts = timedec.Decode(data.PES.Header.OptionalHeader.PTS.Base)
+				}
+
+				cb, ok := mediaCallbacks[data.PID]
+				if !ok {
+					continue
+				}
+
+				cb(pts, data.PES.Data)
+			}
+		}()
+	}()
+
+	select {
+	case err := <-readerErr:
+		return err
+
+	case <-ctx.Done():
+		pc.Close()
+		<-readerErr
+		return fmt.Errorf("terminated")
+	}
+}
+
+// apiSourceDescribe implements sourceStaticImpl.
+func (*udpSource) apiSourceDescribe() interface{} {
+	return struct {
+		Type string `json:"type"`
+	}{"udpSource"}
+}

--- a/rtsp-simple-server.yml
+++ b/rtsp-simple-server.yml
@@ -235,6 +235,7 @@ paths:
     # * rtmps://existing-url -> the stream is pulled from another RTMP server / camera with RTMPS
     # * http://existing-url/stream.m3u8 -> the stream is pulled from another HLS server
     # * https://existing-url/stream.m3u8 -> the stream is pulled from another HLS server with HTTPS
+    # * udp://ip:port -> the stream is pulled from UDP, by listening on the specified IP and port
     # * redirect -> the stream is provided by another path or server
     # * rpiCamera -> the stream is provided by a Raspberry Pi Camera
     source: publisher


### PR DESCRIPTION
Fixes #1481 

## TODO

* [ ] tests

## Nightly release

[rtsp-simple-server_v0.21.6-5-ga45313b_darwin_amd64.tar.gz](https://github.com/aler9/rtsp-simple-server/files/10971934/rtsp-simple-server_v0.21.6-5-ga45313b_darwin_amd64.tar.gz)
[rtsp-simple-server_v0.21.6-5-ga45313b_linux_amd64.tar.gz](https://github.com/aler9/rtsp-simple-server/files/10971936/rtsp-simple-server_v0.21.6-5-ga45313b_linux_amd64.tar.gz)
[rtsp-simple-server_v0.21.6-5-ga45313b_linux_arm64v8.tar.gz](https://github.com/aler9/rtsp-simple-server/files/10971939/rtsp-simple-server_v0.21.6-5-ga45313b_linux_arm64v8.tar.gz)
[rtsp-simple-server_v0.21.6-5-ga45313b_linux_armv6.tar.gz](https://github.com/aler9/rtsp-simple-server/files/10971941/rtsp-simple-server_v0.21.6-5-ga45313b_linux_armv6.tar.gz)
[rtsp-simple-server_v0.21.6-5-ga45313b_linux_armv7.tar.gz](https://github.com/aler9/rtsp-simple-server/files/10971942/rtsp-simple-server_v0.21.6-5-ga45313b_linux_armv7.tar.gz)
[rtsp-simple-server_v0.21.6-5-ga45313b_windows_amd64.zip](https://github.com/aler9/rtsp-simple-server/files/10971945/rtsp-simple-server_v0.21.6-5-ga45313b_windows_amd64.zip)

## Instructions

1. generate a UDP/MPEG-TS directed towards a certain IP and port. For instance:

   ```
   gst-launch-1.0 -v mpegtsmux name=mux alignment=1 ! udpsink  host=238.0.0.1 port=1234 videotestsrc ! video/x-raw,width=1280,height=720 ! x264enc speed-preset=ultrafast bitrate=6000 key-int-max=40 ! mux. audiotestsrc ! audioconvert ! avenc_aac ! mux.
   ```

   MPEG-TS packets can be wrapped each in a single UDP packet or alternatively grouped together by tuning the `alignment` parameter.

   Another example:

   ```
   ffmpeg -stream_loop -1 -re -i vp8_opus.mkv -map 0:a:0 -c copy -f mpegts udp://127.0.0.1:1234?pkt_size=188
   ```

2. Configure the server in this way:

   ```yml
   paths:
     udp:
       source: udp://238.0.0.1:1234
   ```

3. The stream is now accessible through `rtsp://localhost:8554/udp`, `rtmp://localhost/udp`, hls, webrtc, etc..