### PR TITLE
webrtc: fix crash during client disconnection (#1482)

### DIFF
--- a/internal/core/webrtc_conn.go
+++ b/internal/core/webrtc_conn.go
@@ -345,8 +345,12 @@ func (c *webRTCConn) runInner(ctx context.Context) error {
 	pcConnected := make(chan struct{})
 	pcDisconnected := make(chan struct{})
 	pcClosed := make(chan struct{})
+	var stateChangeMutex sync.Mutex
 
 	pc.OnConnectionStateChange(func(state webrtc.PeerConnectionState) {
+		stateChangeMutex.Lock()
+		defer stateChangeMutex.Unlock()
+
 		select {
 		case <-pcClosed:
 			return


### PR DESCRIPTION
Fixes #1482

OnConnectionStateChange of pion/webrtc is not thread safe. Add a mutex to make it thread safe.